### PR TITLE
sql,adapter: Add RETAIN HISTORY PIN AT for pinned history retention

### DIFF
--- a/src/adapter-types/src/compaction.rs
+++ b/src/adapter-types/src/compaction.rs
@@ -43,6 +43,9 @@ pub enum CompactionWindow {
     DisableCompaction,
     /// Create a compaction window for a specified duration.
     Duration(Timestamp),
+    /// Retain history from the given time onward: the since never advances past it, and
+    /// otherwise follows the default compaction lag.
+    PinAt(Timestamp),
 }
 
 impl CompactionWindow {
@@ -51,8 +54,22 @@ impl CompactionWindow {
             CompactionWindow::Default => DEFAULT_LOGICAL_COMPACTION_WINDOW_TS,
             CompactionWindow::DisableCompaction => return Timestamp::minimum(),
             CompactionWindow::Duration(d) => *d,
+            CompactionWindow::PinAt(t) => {
+                return std::cmp::min(
+                    from.saturating_sub(DEFAULT_LOGICAL_COMPACTION_WINDOW_TS),
+                    *t,
+                );
+            }
         };
         from.saturating_sub(lag)
+    }
+
+    /// The time from which history is pinned, if this is a `PinAt` window.
+    pub fn pinned_from(&self) -> Option<Timestamp> {
+        match self {
+            CompactionWindow::PinAt(t) => Some(*t),
+            _ => None,
+        }
     }
 
     /// Returns self as a Timestamp that can be used for comparisons.
@@ -61,6 +78,7 @@ impl CompactionWindow {
             CompactionWindow::Default => DEFAULT_LOGICAL_COMPACTION_WINDOW_TS,
             CompactionWindow::DisableCompaction => Timestamp::maximum(),
             CompactionWindow::Duration(d) => *d,
+            CompactionWindow::PinAt(t) => *t,
         }
     }
 }
@@ -72,6 +90,15 @@ impl From<CompactionWindow> for ReadPolicy {
             CompactionWindow::Duration(time) => time,
             CompactionWindow::DisableCompaction => {
                 return ReadPolicy::ValidFrom(Antichain::from_elem(Timestamp::minimum()));
+            }
+            CompactionWindow::PinAt(t) => {
+                return ReadPolicy::Multiple(vec![
+                    ReadPolicy::lag_writes_by(
+                        DEFAULT_LOGICAL_COMPACTION_WINDOW_TS,
+                        SINCE_GRANULARITY,
+                    ),
+                    ReadPolicy::ValidFrom(Antichain::from_elem(t)),
+                ]);
             }
         };
         ReadPolicy::lag_writes_by(time, SINCE_GRANULARITY)

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -312,6 +312,10 @@ impl CatalogState {
         cw: CompactionWindow,
         diff: Diff,
     ) -> BuiltinTableUpdate<&'static BuiltinTable> {
+        let strategy = match cw {
+            CompactionWindow::PinAt(_) => "PIN AT",
+            _ => "FOR",
+        };
         let cw: u64 = cw.comparable_timestamp().into();
         let cw = Jsonb::from_serde_json(serde_json::Value::Number(serde_json::Number::from(cw)))
             .expect("must serialize");
@@ -319,8 +323,7 @@ impl CatalogState {
             &*MZ_HISTORY_RETENTION_STRATEGIES,
             Row::pack_slice(&[
                 Datum::String(&id.to_string()),
-                // FOR is the only strategy at the moment. We may introduce FROM or others later.
-                Datum::String("FOR"),
+                Datum::String(strategy),
                 cw.into_row().into_element(),
             ]),
             diff,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3223,6 +3223,26 @@ impl Coordinator {
         ctx: &mut ExecuteContext,
         plan: plan::AlterRetainHistoryPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
+        // A pin can only promise history that still exists. Check the storage collections'
+        // read frontiers (indexes rehydrate from their inputs' shards, so they carry no
+        // history of their own to pin).
+        if let CompactionWindow::PinAt(pin) = plan.window {
+            for gid in self.catalog().get_entry(&plan.id).global_ids() {
+                if let Ok(frontiers) = self
+                    .controller
+                    .storage_collections
+                    .collection_frontiers(gid)
+                {
+                    if !frontiers.read_capabilities.less_equal(&pin) {
+                        return Err(AdapterError::Unstructured(anyhow::anyhow!(
+                            "RETAIN HISTORY PIN AT {pin} is before the earliest retained time \
+                             {:?} of the collection; that history is already compacted away",
+                            frontiers.read_capabilities.elements()
+                        )));
+                    }
+                }
+            }
+        }
         let ops = vec![catalog::Op::AlterRetainHistory {
             id: plan.id,
             value: plan.value,

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -641,6 +641,19 @@ impl Coordinator {
 
         let initial_as_of = storage_as_of.clone();
 
+        // A pinned retention must not ask for history from before the earliest time the new
+        // collection can ever be read at: nothing exists there, so a dependent reading at the pin
+        // would otherwise silently see the snapshot at the initial as-of instead.
+        if let Some(CompactionWindow::PinAt(pin)) = compaction_window {
+            if !storage_as_of.less_equal(&pin) {
+                return Err(AdapterError::Unstructured(anyhow::anyhow!(
+                    "RETAIN HISTORY PIN AT {pin} is before the initial as-of {:?} of the \
+                     materialized view; the pin must be at or after it",
+                    storage_as_of.elements()
+                )));
+            }
+        }
+
         // Update the `create_sql` with the selected `as_of`. This is how we make sure the `as_of`
         // is persisted to the catalog and can be relied on during bootstrapping.
         // This has to be the `storage_as_of`, because bootstrapping uses this in

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -2370,7 +2370,11 @@ impl CatalogItem {
                     if let Some(value) = value {
                         let next = mz_sql_parser::ast::$opt {
                             name: mz_sql_parser::ast::$name::RetainHistory,
-                            value: Some(WithOptionValue::RetainHistoryFor(value)),
+                            value: Some(if matches!(window, CompactionWindow::PinAt(_)) {
+                                WithOptionValue::RetainHistoryPinAt(value)
+                            } else {
+                                WithOptionValue::RetainHistoryFor(value)
+                            }),
                         };
                         if let Some(idx) = pos {
                             let previous = $stmt.with_options[idx].clone();
@@ -4129,6 +4133,10 @@ impl mz_sql::catalog::CatalogClusterReplica<'_> for ClusterReplica {
 }
 
 impl mz_sql::catalog::CatalogItem for CatalogEntry {
+    fn compaction_window(&self) -> Option<CompactionWindow> {
+        self.item().custom_logical_compaction_window()
+    }
+
     fn name(&self) -> &QualifiedItemName {
         self.name()
     }

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -84,6 +84,7 @@ Catalog
 Certificate
 Chain
 Chains
+Changes
 Char
 Character
 Characteristics
@@ -360,6 +361,7 @@ Password
 Path
 Pattern
 Physical
+Pin
 Plan
 Plans
 Policies
@@ -451,6 +453,7 @@ Session
 Set
 Shard
 Show
+Since
 Sink
 Sinks
 Size

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -4576,6 +4576,7 @@ pub enum WithOptionValue<T: AstInfo> {
     ConnectionAwsPrivatelink(ConnectionDefaultAwsPrivatelink<T>),
     KafkaMatchingBrokerRule(KafkaMatchingBrokerRule<T>),
     RetainHistoryFor(Value),
+    RetainHistoryPinAt(Value),
     Refresh(RefreshOptionValue<T>),
     ClusterScheduleOptionValue(ClusterScheduleOptionValue),
     ClusterAutoScalingStrategyOptionValue(ClusterAutoScalingStrategyOptionValue),
@@ -4593,6 +4594,7 @@ impl<T: AstInfo> AstDisplay for WithOptionValue<T> {
                 | WithOptionValue::Sequence(_)
                 | WithOptionValue::Map(_)
                 | WithOptionValue::RetainHistoryFor(_)
+                | WithOptionValue::RetainHistoryPinAt(_)
                 | WithOptionValue::Refresh(_)
                 | WithOptionValue::Expr(_) => {
                     // These are redact-aware.
@@ -4673,6 +4675,10 @@ impl<T: AstInfo> AstDisplay for WithOptionValue<T> {
             }
             WithOptionValue::RetainHistoryFor(value) => {
                 f.write_str("FOR ");
+                f.write_node(value);
+            }
+            WithOptionValue::RetainHistoryPinAt(value) => {
+                f.write_str("PIN AT ");
                 f.write_node(value);
             }
             WithOptionValue::Refresh(opt) => f.write_node(opt),

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4290,6 +4290,11 @@ impl<'a> Parser<'a> {
 
     fn parse_retain_history(&mut self) -> Result<WithOptionValue<Raw>, ParserError> {
         let _ = self.consume_token(&Token::Eq);
+        if self.parse_keyword(PIN) {
+            self.expect_keyword(AT)?;
+            let value = self.parse_value()?;
+            return Ok(WithOptionValue::RetainHistoryPinAt(value));
+        }
         self.expect_keyword(FOR)?;
         let value = self.parse_value()?;
         Ok(WithOptionValue::RetainHistoryFor(value))

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -916,6 +916,11 @@ pub trait CatalogItem {
     /// Returns the cluster the item belongs to.
     fn cluster_id(&self) -> Option<ClusterId>;
 
+    /// The custom history retention policy of the item, if any.
+    fn compaction_window(&self) -> Option<mz_adapter_types::compaction::CompactionWindow> {
+        None
+    }
+
     /// Returns the [`CatalogCollectionItem`] for a specific version of this
     /// [`CatalogItem`].
     fn at_version(&self, version: RelationVersionSelector) -> Box<dyn CatalogCollectionItem>;

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -2066,6 +2066,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                 KafkaMatchingBrokerRule(self.fold_kafka_matching_broker_rule(x))
             }
             RetainHistoryFor(value) => RetainHistoryFor(self.fold_value(value)),
+            RetainHistoryPinAt(value) => RetainHistoryPinAt(self.fold_value(value)),
             Refresh(refresh) => Refresh(self.fold_refresh_option_value(refresh)),
             ClusterScheduleOptionValue(value) => ClusterScheduleOptionValue(value),
             ClusterAutoScalingStrategyOptionValue(value) => {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -21,6 +21,8 @@ use std::time::Duration;
 use chrono::DateTime;
 use itertools::Itertools;
 use mz_adapter_types::compaction::{CompactionWindow, DEFAULT_LOGICAL_COMPACTION_WINDOW_DURATION};
+
+use crate::plan::with_options::RetainHistoryValue;
 use mz_arrow_util::builder::ArrowBuilder;
 use mz_auth::password::Password;
 use mz_controller_types::{ClusterId, DEFAULT_REPLICA_LOGGING_INTERVAL, ReplicaId};
@@ -537,7 +539,7 @@ pub fn describe_create_subsource(
 generate_extracted_config!(
     CreateSourceOption,
     (TimestampInterval, Duration),
-    (RetainHistory, OptionalDuration)
+    (RetainHistory, RetainHistoryValue)
 );
 
 generate_extracted_config!(
@@ -1586,7 +1588,7 @@ generate_extracted_config!(
     CreateSubsourceOption,
     (Progress, bool, Default(false)),
     (ExternalReference, UnresolvedItemName),
-    (RetainHistory, OptionalDuration),
+    (RetainHistory, RetainHistoryValue),
     (TextColumns, Vec::<Ident>, Default(vec![])),
     (ExcludeColumns, Vec::<Ident>, Default(vec![])),
     (Details, String)
@@ -1749,7 +1751,7 @@ generate_extracted_config!(
     (TextColumns, Vec::<Ident>, Default(vec![])),
     (ExcludeColumns, Vec::<Ident>, Default(vec![])),
     (PartitionBy, Vec<Ident>),
-    (RetainHistory, OptionalDuration),
+    (RetainHistory, RetainHistoryValue),
     (Details, String)
 );
 
@@ -3208,7 +3210,7 @@ generate_extracted_config!(
     MaterializedViewOption,
     (AssertNotNull, Ident, AllowMultiple),
     (PartitionBy, Vec<Ident>),
-    (RetainHistory, OptionalDuration),
+    (RetainHistory, RetainHistoryValue),
     (Refresh, RefreshOptionValue<Aug>, AllowMultiple)
 );
 
@@ -6488,12 +6490,17 @@ pub fn plan_drop_owned(
 
 fn plan_retain_history_option(
     scx: &StatementContext,
-    retain_history: Option<OptionalDuration>,
+    retain_history: Option<RetainHistoryValue>,
 ) -> Result<Option<CompactionWindow>, PlanError> {
-    if let Some(OptionalDuration(lcw)) = retain_history {
-        Ok(Some(plan_retain_history(scx, lcw)?))
-    } else {
-        Ok(None)
+    match retain_history {
+        Some(RetainHistoryValue::For(OptionalDuration(lcw))) => {
+            Ok(Some(plan_retain_history(scx, lcw)?))
+        }
+        Some(RetainHistoryValue::PinAt(ts)) => {
+            scx.require_feature_flag(&vars::ENABLE_LOGICAL_COMPACTION_WINDOW)?;
+            Ok(Some(CompactionWindow::PinAt(ts)))
+        }
+        None => Ok(None),
     }
 }
 
@@ -6547,7 +6554,7 @@ fn plan_retain_history(
     }
 }
 
-generate_extracted_config!(IndexOption, (RetainHistory, OptionalDuration));
+generate_extracted_config!(IndexOption, (RetainHistory, RetainHistoryValue));
 
 fn plan_index_options(
     scx: &StatementContext,
@@ -6570,7 +6577,7 @@ fn plan_index_options(
 generate_extracted_config!(
     TableOption,
     (PartitionBy, Vec<Ident>),
-    (RetainHistory, OptionalDuration),
+    (RetainHistory, RetainHistoryValue),
     (RedactedTest, String)
 );
 
@@ -7542,16 +7549,28 @@ fn alter_retain_history(
             }
 
             // Save the original value so we can write it back down in the create_sql catalog item.
-            let (value, lcw) = match &history {
+            let (value, window) = match &history {
                 Some(WithOptionValue::RetainHistoryFor(value)) => {
                     let window = OptionalDuration::try_from_value(value.clone())?;
-                    (Some(value.clone()), window.0)
+                    (Some(value.clone()), plan_retain_history(scx, window.0)?)
+                }
+                Some(WithOptionValue::RetainHistoryPinAt(value)) => {
+                    let RetainHistoryValue::PinAt(ts) = RetainHistoryValue::try_from_value(
+                        WithOptionValue::<Aug>::RetainHistoryPinAt(value.clone()),
+                    )?
+                    else {
+                        unreachable!("PIN AT values plan to RetainHistoryValue::PinAt")
+                    };
+                    scx.require_feature_flag(&vars::ENABLE_LOGICAL_COMPACTION_WINDOW)?;
+                    (Some(value.clone()), CompactionWindow::PinAt(ts))
                 }
                 // None is RESET, so use the default CW.
-                None => (None, Some(DEFAULT_LOGICAL_COMPACTION_WINDOW_DURATION)),
+                None => (
+                    None,
+                    plan_retain_history(scx, Some(DEFAULT_LOGICAL_COMPACTION_WINDOW_DURATION))?,
+                ),
                 _ => sql_bail!("unexpected value type for RETAIN HISTORY"),
             };
-            let window = plan_retain_history(scx, lcw)?;
 
             Ok(Plan::AlterRetainHistory(AlterRetainHistoryPlan {
                 id: entry.id(),

--- a/src/sql/src/plan/with_options.rs
+++ b/src/sql/src/plan/with_options.rs
@@ -464,6 +464,56 @@ impl ImpliedValue for OptionalDuration {
     }
 }
 
+/// The value of a `RETAIN HISTORY` option: a duration to lag the write frontier by, or a fixed
+/// time from which history is retained.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RetainHistoryValue {
+    For(OptionalDuration),
+    PinAt(mz_repr::Timestamp),
+}
+
+impl<T: AstInfo + std::fmt::Debug> TryFromValue<WithOptionValue<T>> for RetainHistoryValue {
+    fn try_from_value(v: WithOptionValue<T>) -> Result<Self, PlanError> {
+        match v {
+            WithOptionValue::RetainHistoryPinAt(value) => {
+                let s = match value {
+                    Value::Number(n) => n,
+                    Value::String(s) => s,
+                    other => sql_bail!("invalid RETAIN HISTORY PIN AT value: {other:?}"),
+                };
+                let ts = s.parse::<mz_repr::Timestamp>().map_err(|e| {
+                    PlanError::Unstructured(format!("invalid RETAIN HISTORY PIN AT value: {e}"))
+                })?;
+                Ok(RetainHistoryValue::PinAt(ts))
+            }
+            v => Ok(RetainHistoryValue::For(OptionalDuration::try_from_value(
+                v,
+            )?)),
+        }
+    }
+
+    fn try_into_value(self, catalog: &dyn SessionCatalog) -> Option<WithOptionValue<T>> {
+        match self {
+            RetainHistoryValue::For(d) => Some(WithOptionValue::RetainHistoryFor(
+                d.try_into_value(catalog)?,
+            )),
+            RetainHistoryValue::PinAt(ts) => Some(WithOptionValue::RetainHistoryPinAt(
+                Value::Number(ts.to_string()),
+            )),
+        }
+    }
+
+    fn name() -> String {
+        "retain history value".to_string()
+    }
+}
+
+impl ImpliedValue for RetainHistoryValue {
+    fn implied_value() -> Result<Self, PlanError> {
+        sql_bail!("must provide a RETAIN HISTORY value")
+    }
+}
+
 impl TryFromValue<Value> for String {
     fn try_from_value(v: Value) -> Result<Self, PlanError> {
         match v {
@@ -724,7 +774,8 @@ impl<V: TryFromValue<Value>, T: AstInfo + std::fmt::Debug> TryFromValue<WithOpti
             }
             WithOptionValue::Ident(v) => V::try_from_value(Value::String(v.into_string())),
             WithOptionValue::RetainHistoryFor(v) => V::try_from_value(v),
-            WithOptionValue::Sequence(_)
+            WithOptionValue::RetainHistoryPinAt(_)
+            | WithOptionValue::Sequence(_)
             | WithOptionValue::Map(_)
             | WithOptionValue::Item(_)
             | WithOptionValue::UnresolvedItemName(_)
@@ -745,6 +796,7 @@ impl<V: TryFromValue<Value>, T: AstInfo + std::fmt::Debug> TryFromValue<WithOpti
                     // The first few are unreachable because they are handled at the top of the outer match.
                     WithOptionValue::Value(_) => unreachable!(),
                     WithOptionValue::RetainHistoryFor(_) => unreachable!(),
+                    WithOptionValue::RetainHistoryPinAt(_) => "retain history pins",
                     WithOptionValue::ClusterAlterStrategy(_) => "cluster alter strategy",
                     WithOptionValue::Sequence(_) => "sequences",
                     WithOptionValue::Map(_) => "maps",


### PR DESCRIPTION
**Draft, PR 1 of 3** (`pin` -> `changes` -> `correlated-asof`). Spike quality; opened for discussion.

### Motivation

`RETAIN HISTORY FOR <duration>` retains history relative to the write frontier, so a reader that needs a collection's history from a *fixed* time onward, indefinitely, has nothing to lean on: the since eventually passes any time it might name. Two such readers are in the following PRs, `CHANGES(x AS OF t)` and correlated `AS OF SYSTEM TIME`. Both need "the since of `x` never advances past `t`", and both need it to be a durable fact they can check statically, not an in-memory read hold.

### What this adds

- `RETAIN HISTORY [=] PIN AT <time>` on tables, sources, materialized views and indexes, also via `ALTER ... SET (RETAIN HISTORY PIN AT <time>)`. `<time>` is a number of milliseconds or a timestamp string, parsed with `mz_repr::Timestamp::from_str`.
- `CompactionWindow::PinAt(t)`, lowered to `ReadPolicy::Multiple([lag_writes_by(default), ValidFrom(t)])`: the since follows the default lag until it reaches `t`, then holds.
- The pin is a catalog fact. It round-trips through the item's SQL (so it survives restarts), is reported as strategy `PIN AT` in `mz_internal.mz_history_retention_strategies`, and is exposed to the planner via a new `CatalogItem::compaction_window()` so dependents can check `pin <= t` at planning time.
- Guards: `CREATE MATERIALIZED VIEW` refuses a pin below the view's initial as-of, and `ALTER` refuses a pin below the collection's current read frontier, since that history no longer exists. (`ALTER` also refuses to move a pin past a dependent's CHANGES literal, but that check lands in PR 2 where the dependents exist.)

Observed on a local instance: after `CREATE MATERIALIZED VIEW mv WITH (RETAIN HISTORY = PIN AT 1788537747100) ...`, `mz_internal.mz_frontiers` reports `mv`'s read frontier at exactly `1788537747100` while its input table compacts to about one second behind its upper.

### Not done here

- `PIN AT` on `CREATE TABLE` / `CREATE SOURCE` is not validated against the initial since; MVs and `ALTER` are.
- No new feature flag; the existing `enable_logical_compaction_window` gate applies. A dedicated flag (off in production, on in CI) should be added before this leaves draft.
- A pinned collection's *state* costs history-proportional reads (persist consolidates all retained updates on every snapshot read). Measured in PR 2: hydrating an index over a pinned 100k-row view with 1.1M retained updates took 11.5s against 3.5s for an unpinned twin. This is inherent to pinning a shard's since; the mitigation is to pin a second, derived view rather than the one everyone reads.

### Tests

Parser round-trip cases for the new option forms in `src/sql-parser/tests/testdata/create`.

Release note: none while draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
