### PR TITLE
sql: Add correlated x AS OF SYSTEM TIME t SINCE l reads over pinned history

### DIFF
--- a/src/adapter-types/src/compaction.rs
+++ b/src/adapter-types/src/compaction.rs
@@ -43,6 +43,9 @@ pub enum CompactionWindow {
     DisableCompaction,
     /// Create a compaction window for a specified duration.
     Duration(Timestamp),
+    /// Retain history from the given time onward: the since never advances past it, and
+    /// otherwise follows the default compaction lag.
+    PinAt(Timestamp),
 }
 
 impl CompactionWindow {
@@ -51,8 +54,22 @@ impl CompactionWindow {
             CompactionWindow::Default => DEFAULT_LOGICAL_COMPACTION_WINDOW_TS,
             CompactionWindow::DisableCompaction => return Timestamp::minimum(),
             CompactionWindow::Duration(d) => *d,
+            CompactionWindow::PinAt(t) => {
+                return std::cmp::min(
+                    from.saturating_sub(DEFAULT_LOGICAL_COMPACTION_WINDOW_TS),
+                    *t,
+                );
+            }
         };
         from.saturating_sub(lag)
+    }
+
+    /// The time from which history is pinned, if this is a `PinAt` window.
+    pub fn pinned_from(&self) -> Option<Timestamp> {
+        match self {
+            CompactionWindow::PinAt(t) => Some(*t),
+            _ => None,
+        }
     }
 
     /// Returns self as a Timestamp that can be used for comparisons.
@@ -61,6 +78,7 @@ impl CompactionWindow {
             CompactionWindow::Default => DEFAULT_LOGICAL_COMPACTION_WINDOW_TS,
             CompactionWindow::DisableCompaction => Timestamp::maximum(),
             CompactionWindow::Duration(d) => *d,
+            CompactionWindow::PinAt(t) => *t,
         }
     }
 }
@@ -72,6 +90,15 @@ impl From<CompactionWindow> for ReadPolicy {
             CompactionWindow::Duration(time) => time,
             CompactionWindow::DisableCompaction => {
                 return ReadPolicy::ValidFrom(Antichain::from_elem(Timestamp::minimum()));
+            }
+            CompactionWindow::PinAt(t) => {
+                return ReadPolicy::Multiple(vec![
+                    ReadPolicy::lag_writes_by(
+                        DEFAULT_LOGICAL_COMPACTION_WINDOW_TS,
+                        SINCE_GRANULARITY,
+                    ),
+                    ReadPolicy::ValidFrom(Antichain::from_elem(t)),
+                ]);
             }
         };
         ReadPolicy::lag_writes_by(time, SINCE_GRANULARITY)

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -312,6 +312,10 @@ impl CatalogState {
         cw: CompactionWindow,
         diff: Diff,
     ) -> BuiltinTableUpdate<&'static BuiltinTable> {
+        let strategy = match cw {
+            CompactionWindow::PinAt(_) => "PIN AT",
+            _ => "FOR",
+        };
         let cw: u64 = cw.comparable_timestamp().into();
         let cw = Jsonb::from_serde_json(serde_json::Value::Number(serde_json::Number::from(cw)))
             .expect("must serialize");
@@ -319,8 +323,7 @@ impl CatalogState {
             &*MZ_HISTORY_RETENTION_STRATEGIES,
             Row::pack_slice(&[
                 Datum::String(&id.to_string()),
-                // FOR is the only strategy at the moment. We may introduce FROM or others later.
-                Datum::String("FOR"),
+                Datum::String(strategy),
                 cw.into_row().into_element(),
             ]),
             diff,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3243,6 +3243,48 @@ impl Coordinator {
                 }
             }
         }
+        // Dependents reading CHANGES from this item need its history from their AS OF onward,
+        // so the pin may neither move past the earliest such literal nor become a lag.
+        let entry = self.catalog().get_entry(&plan.id);
+        let gids: std::collections::BTreeSet<GlobalId> = entry.global_ids().collect();
+        let mut earliest_changes_read: Option<(CatalogItemId, mz_repr::Timestamp)> = None;
+        for dep_id in entry.used_by() {
+            let expr = match self.catalog().get_entry(dep_id).item() {
+                CatalogItem::View(view) => Some(view.locally_optimized_expr.as_ref().clone()),
+                CatalogItem::MaterializedView(mview) => {
+                    Some(mview.locally_optimized_expr.as_ref().clone())
+                }
+                _ => None,
+            };
+            if let Some(expr) = expr {
+                expr.as_inner().visit_pre(|e| {
+                    if let mz_expr::MirRelationExpr::Get {
+                        id: mz_expr::Id::Global(id),
+                        changes_as_of: Some(t),
+                        ..
+                    } = e
+                    {
+                        if gids.contains(id)
+                            && earliest_changes_read.is_none_or(|(_, cur)| *t < cur)
+                        {
+                            earliest_changes_read = Some((*dep_id, *t));
+                        }
+                    }
+                });
+            }
+        }
+        if let Some((dep_id, t)) = earliest_changes_read {
+            if !matches!(plan.window, CompactionWindow::PinAt(pin) if pin <= t) {
+                let conn_id = Some(ctx.session().conn_id());
+                let name = self.catalog().resolve_full_name(entry.name(), conn_id);
+                let dep = self.catalog().get_entry(&dep_id);
+                let dep_name = self.catalog().resolve_full_name(dep.name(), conn_id);
+                return Err(AdapterError::Unstructured(anyhow::anyhow!(
+                    "cannot change RETAIN HISTORY of {name}: {dep_name} reads CHANGES AS OF {t}, \
+                     which requires RETAIN HISTORY PIN AT at or before {t}"
+                )));
+            }
+        }
         let ops = vec![catalog::Op::AlterRetainHistory {
             id: plan.id,
             value: plan.value,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3223,6 +3223,26 @@ impl Coordinator {
         ctx: &mut ExecuteContext,
         plan: plan::AlterRetainHistoryPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
+        // A pin can only promise history that still exists. Check the storage collections'
+        // read frontiers (indexes rehydrate from their inputs' shards, so they carry no
+        // history of their own to pin).
+        if let CompactionWindow::PinAt(pin) = plan.window {
+            for gid in self.catalog().get_entry(&plan.id).global_ids() {
+                if let Ok(frontiers) = self
+                    .controller
+                    .storage_collections
+                    .collection_frontiers(gid)
+                {
+                    if !frontiers.read_capabilities.less_equal(&pin) {
+                        return Err(AdapterError::Unstructured(anyhow::anyhow!(
+                            "RETAIN HISTORY PIN AT {pin} is before the earliest retained time \
+                             {:?} of the collection; that history is already compacted away",
+                            frontiers.read_capabilities.elements()
+                        )));
+                    }
+                }
+            }
+        }
         let ops = vec![catalog::Op::AlterRetainHistory {
             id: plan.id,
             value: plan.value,

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -641,6 +641,19 @@ impl Coordinator {
 
         let initial_as_of = storage_as_of.clone();
 
+        // A pinned retention must not ask for history from before the earliest time the new
+        // collection can ever be read at: nothing exists there, so a dependent reading at the pin
+        // would otherwise silently see the snapshot at the initial as-of instead.
+        if let Some(CompactionWindow::PinAt(pin)) = compaction_window {
+            if !storage_as_of.less_equal(&pin) {
+                return Err(AdapterError::Unstructured(anyhow::anyhow!(
+                    "RETAIN HISTORY PIN AT {pin} is before the initial as-of {:?} of the \
+                     materialized view; the pin must be at or after it",
+                    storage_as_of.elements()
+                )));
+            }
+        }
+
         // Update the `create_sql` with the selected `as_of`. This is how we make sure the `as_of`
         // is persisted to the catalog and can be relied on during bootstrapping.
         // This has to be the `storage_as_of`, because bootstrapping uses this in

--- a/src/adapter/src/frontend_read_then_write.rs
+++ b/src/adapter/src/frontend_read_then_write.rs
@@ -2137,6 +2137,7 @@ fn apply_mutation_to_mir(
                 id: Id::Local(binding_id),
                 typ: expr.typ(),
                 access_strategy: mz_expr::AccessStrategy::UnknownOrLocal,
+                changes_as_of: None,
             };
 
             let map_scalars: Vec<MirScalarExpr> = (0..arity)

--- a/src/adapter/src/optimize/dataflows.rs
+++ b/src/adapter/src/optimize/dataflows.rs
@@ -312,6 +312,14 @@ impl<'a> DataflowBuilder<'a> {
         features: &OptimizerFeatures,
     ) -> Result<(), OptimizerError> {
         maybe_grow(|| {
+            if let Some(import) = dataflow.source_imports.get(id) {
+                if let Some(as_of) = import.desc.arguments.changes_as_of {
+                    return Err(OptimizerError::Internal(format!(
+                        "collection {id} cannot be read both directly and as CHANGES AS OF \
+                         {as_of} within one dataflow"
+                    )));
+                }
+            }
             // Avoid importing the item redundantly.
             if dataflow.is_imported(id) {
                 return Ok(());
@@ -399,10 +407,78 @@ impl<'a> DataflowBuilder<'a> {
         dataflow: &mut DataflowDesc,
         features: &OptimizerFeatures,
     ) -> Result<(), OptimizerError> {
-        for get_id in view.depends_on() {
+        // CHANGES reads are imports of a different shape than plain reads of the same id, so
+        // they are registered first and plain imports of the same id are then rejected.
+        let mut changes_reads = BTreeMap::new();
+        let mut plain_reads = BTreeSet::new();
+        view.as_inner().visit_pre(|expr| {
+            if let MirRelationExpr::Get {
+                id: Id::Global(id),
+                changes_as_of,
+                ..
+            } = expr
+            {
+                match changes_as_of {
+                    Some(as_of) => {
+                        changes_reads.entry(*id).or_insert(*as_of);
+                    }
+                    None => {
+                        plain_reads.insert(*id);
+                    }
+                }
+            }
+        });
+        for (id, as_of) in changes_reads {
+            if plain_reads.contains(&id) {
+                return Err(OptimizerError::Internal(format!(
+                    "collection {id} cannot be read both directly and as CHANGES AS OF {as_of} \
+                     within one dataflow"
+                )));
+            }
+            self.import_changes_into_dataflow(&id, as_of, dataflow)?;
+        }
+        for get_id in plain_reads {
             self.import_into_dataflow(&get_id, dataflow, features)?;
         }
         dataflow.insert_plan(*view_id, view.clone());
+        Ok(())
+    }
+
+    /// Imports the history of `id` from `as_of` onward, as read by `CHANGES(id AS OF as_of)`.
+    ///
+    /// The read goes to the persist shard regardless of available indexes, because only the
+    /// shard's pinned since guarantees the history is present.
+    fn import_changes_into_dataflow(
+        &mut self,
+        id: &GlobalId,
+        as_of: mz_repr::Timestamp,
+        dataflow: &mut DataflowDesc,
+    ) -> Result<(), OptimizerError> {
+        if let Some(import) = dataflow.source_imports.get(id) {
+            if import.desc.arguments.changes_as_of == Some(as_of) {
+                return Ok(());
+            }
+        }
+        if dataflow.is_imported(id) {
+            return Err(OptimizerError::Internal(format!(
+                "collection {id} cannot be read both directly and as CHANGES AS OF {as_of} \
+                 within one dataflow"
+            )));
+        }
+        let entry = self.catalog.get_entry(id);
+        if !matches!(
+            entry.item(),
+            CatalogItem::Table(_) | CatalogItem::Source(_) | CatalogItem::MaterializedView(_)
+        ) {
+            return Err(OptimizerError::Internal(format!(
+                "CHANGES requires a persist-backed collection, but {id} is not one"
+            )));
+        }
+        let desc = entry.relation_desc().ok_or_else(|| {
+            OptimizerError::Internal(format!("CHANGES source {id} has no relation description"))
+        })?;
+        let typ = mz_sql::plan::changes_desc(&desc).typ().clone();
+        dataflow.import_changes(*id, typ, as_of);
         Ok(())
     }
 

--- a/src/adapter/src/optimize/metric_sink.rs
+++ b/src/adapter/src/optimize/metric_sink.rs
@@ -840,6 +840,7 @@ mod tests {
         let expr = HirRelationExpr::Get {
             id: mz_expr::Id::Global(TABLE_GID),
             typ: desc.typ().clone(),
+            changes_as_of: None,
         };
 
         let df_desc = optimize_from(

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -2370,7 +2370,11 @@ impl CatalogItem {
                     if let Some(value) = value {
                         let next = mz_sql_parser::ast::$opt {
                             name: mz_sql_parser::ast::$name::RetainHistory,
-                            value: Some(WithOptionValue::RetainHistoryFor(value)),
+                            value: Some(if matches!(window, CompactionWindow::PinAt(_)) {
+                                WithOptionValue::RetainHistoryPinAt(value)
+                            } else {
+                                WithOptionValue::RetainHistoryFor(value)
+                            }),
                         };
                         if let Some(idx) = pos {
                             let previous = $stmt.with_options[idx].clone();
@@ -4129,6 +4133,10 @@ impl mz_sql::catalog::CatalogClusterReplica<'_> for ClusterReplica {
 }
 
 impl mz_sql::catalog::CatalogItem for CatalogEntry {
+    fn compaction_window(&self) -> Option<CompactionWindow> {
+        self.item().custom_logical_compaction_window()
+    }
+
     fn name(&self) -> &QualifiedItemName {
         self.name()
     }

--- a/src/compute-client/src/as_of_selection.rs
+++ b/src/compute-client/src/as_of_selection.rs
@@ -1069,6 +1069,7 @@ mod tests {
                 let desc = SourceInstanceDesc {
                     arguments: SourceInstanceArguments {
                         operators: Default::default(),
+                        changes_as_of: None,
                     },
                     storage_metadata: Default::default(),
                     typ: SqlRelationType::empty(),

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -158,10 +158,34 @@ impl DataflowDescription<OptimizedMirRelationExpr, ()> {
             SourceImport {
                 desc: SourceInstanceDesc {
                     storage_metadata: (),
-                    arguments: SourceInstanceArguments { operators: None },
+                    arguments: SourceInstanceArguments {
+                        operators: None,
+                        changes_as_of: None,
+                    },
                     typ,
                 },
                 monotonic,
+                with_snapshot: true,
+                upper: Antichain::new(),
+            },
+        );
+    }
+
+    /// Imports the history of the source `id` from `as_of` onward as an append-only collection
+    /// of promoted `(row..., mz_timestamp, mz_diff)` rows; `typ` describes those rows.
+    pub fn import_changes(&mut self, id: GlobalId, typ: SqlRelationType, as_of: Timestamp) {
+        self.source_imports.insert(
+            id,
+            SourceImport {
+                desc: SourceInstanceDesc {
+                    storage_metadata: (),
+                    arguments: SourceInstanceArguments {
+                        operators: None,
+                        changes_as_of: Some(as_of),
+                    },
+                    typ,
+                },
+                monotonic: true,
                 with_snapshot: true,
                 upper: Antichain::new(),
             },
@@ -684,7 +708,10 @@ mod tests {
     fn dataflow(plan: MirRelationExpr) -> DataflowDesc {
         let source_import = || SourceImport {
             desc: SourceInstanceDesc {
-                arguments: SourceInstanceArguments { operators: None },
+                arguments: SourceInstanceArguments {
+                    operators: None,
+                    changes_as_of: None,
+                },
                 storage_metadata: (),
                 typ: SqlRelationType::from_repr(&typ()),
             },
@@ -723,6 +750,7 @@ mod tests {
             id: Id::Global(READ),
             typ: typ(),
             access_strategy: AccessStrategy::Persist,
+            changes_as_of: None,
         });
 
         assert_eq!(df.used_import_ids(), BTreeSet::from([READ]));
@@ -755,6 +783,7 @@ mod tests {
                 id: Id::Global(UNREAD),
                 typ: typ(),
                 access_strategy: AccessStrategy::Persist,
+                changes_as_of: None,
             }),
         });
         df.index_exports.insert(
@@ -782,6 +811,7 @@ mod tests {
             id: Id::Global(indexed_view),
             typ: typ(),
             access_strategy: AccessStrategy::Index(Vec::new()),
+            changes_as_of: None,
         });
         df.index_imports.insert(
             imported_index,

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -223,6 +223,10 @@ impl Context {
     fn refine_source_mfps(&mut self, dataflow: &mut DataflowDescription<LirRelationExpr>) {
         for (source_id, source_import) in dataflow.source_imports.iter_mut() {
             let source = &mut source_import.desc;
+            // A CHANGES import's rows differ from the shard's rows; its reads keep their MFPs.
+            if source.arguments.changes_as_of.is_some() {
+                continue;
+            }
             let source_id = *source_id;
             let mut identity_present = false;
 

--- a/src/compute-types/src/sources.rs
+++ b/src/compute-types/src/sources.rs
@@ -32,4 +32,8 @@ pub struct SourceInstanceDesc<M> {
 pub struct SourceInstanceArguments {
     /// Linear operators to be applied record-by-record.
     pub operators: Option<mz_expr::MapFilterProject>,
+    /// If set, read the shard at this fixed as-of (not the dataflow's) and promote each
+    /// consolidated update's time and diff to trailing `mz_timestamp` and `mz_diff` columns.
+    /// `operators` must be `None`: the shard's rows do not have the promoted columns.
+    pub changes_as_of: Option<mz_repr::Timestamp>,
 }

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -148,7 +148,7 @@ use timely::PartialOrder;
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::vec::ToStream;
-use timely::dataflow::operators::vec::{BranchWhen, Filter};
+use timely::dataflow::operators::vec::{BranchWhen, Filter, Map};
 use timely::dataflow::operators::{Capability, Operator, Probe, probe};
 use timely::dataflow::{Scope, Stream, StreamVec};
 use timely::order::{Product, TotalOrder};
@@ -253,7 +253,7 @@ pub fn build_compute_dataflow(
             for (source_id, import) in dataflow.source_imports.iter() {
                 region.region_named(&format!("Source({:?})", source_id), |inner| {
                     let mut read_schema = None;
-                    let mut mfp = import.desc.arguments.operators.clone().map(|mut ops| {
+                    let mfp = import.desc.arguments.operators.clone().map(|mut ops| {
                         // If enabled, we read from Persist with a `RelationDesc` that
                         // omits uneeded columns.
                         if apply_demands {
@@ -286,9 +286,22 @@ pub fn build_compute_dataflow(
                     };
                     let suppress_early_progress_as_of = dataflow.as_of.clone();
 
+                    // A CHANGES import reads the shard at its own fixed as-of and unfiltered;
+                    // the promotion below then advances its times to the dataflow as-of.
+                    let changes_as_of = import.desc.arguments.changes_as_of;
+                    let (read_as_of, snapshot_mode, read_schema, mut mfp) = match changes_as_of {
+                        Some(t) => (
+                            Some(Antichain::from_elem(t)),
+                            SnapshotMode::Include,
+                            None,
+                            None,
+                        ),
+                        None => (dataflow.as_of.clone(), snapshot_mode, read_schema, mfp),
+                    };
+
                     // Note: For correctness, we require that sources only emit times advanced by
                     // `dataflow.as_of`. `persist_source` is documented to provide this guarantee.
-                    let (mut ok_stream, err_stream, token) =
+                    let (mut ok_stream, mut err_stream, token) =
                         persist_source::persist_source::<DataflowErrorSer>(
                             inner,
                             *source_id,
@@ -296,7 +309,7 @@ pub fn build_compute_dataflow(
                             &compute_state.txns_ctx,
                             import.desc.storage_metadata.clone(),
                             read_schema,
-                            dataflow.as_of.clone(),
+                            read_as_of,
                             snapshot_mode,
                             until.clone(),
                             mfp.as_mut(),
@@ -308,6 +321,41 @@ pub fn build_compute_dataflow(
                     // If `mfp` is non-identity, we need to apply what remains.
                     // For the moment, assert that it is either trivial or `None`.
                     assert!(mfp.map(|x| x.is_identity()).unwrap_or(true));
+
+                    if changes_as_of.is_some() {
+                        // Consolidate per (row, time) first: the shard's batch layout is not
+                        // canonical, but the consolidated update at each time is, given the
+                        // shard's since is at or before the read as-of. Then promote time and
+                        // diff to data, and advance everything to the dataflow as-of so the
+                        // as-of guarantee above holds for the promoted rows too.
+                        let dataflow_as_of =
+                            dataflow.as_of.as_ref().and_then(|f| f.as_option().copied());
+                        let oks = CollectionExt::consolidate_named::<KeyBatcher<_, _, _>>(
+                            ok_stream.as_collection(),
+                            "ChangesConsolidate",
+                        );
+                        let oks = oks
+                            .inner
+                            .map(|(row, time, diff): (Row, mz_repr::Timestamp, Diff)| {
+                                let mut out = Row::default();
+                                let mut packer = out.packer();
+                                packer.extend(row.iter());
+                                packer.push(Datum::MzTimestamp(time));
+                                packer.push(Datum::Int64(diff.into_inner()));
+                                (out, time, Diff::ONE)
+                            })
+                            .as_collection();
+                        let errs = err_stream.as_collection();
+                        let (oks, errs) = match dataflow_as_of {
+                            Some(as_of) => (
+                                oks.delay(move |t| std::cmp::max(*t, as_of)),
+                                errs.delay(move |t| std::cmp::max(*t, as_of)),
+                            ),
+                            None => (oks, errs),
+                        };
+                        ok_stream = oks.inner;
+                        err_stream = errs.inner;
+                    }
 
                     // To avoid a memory spike during arrangement hydration (database-issues#6368), need to
                     // ensure that the first frontier we report into the dataflow is beyond the

--- a/src/expr-parser/src/parser.rs
+++ b/src/expr-parser/src/parser.rs
@@ -240,11 +240,13 @@ mod relation {
                 id: Id::Global(*id),
                 typ: ReprRelationType::from(typ),
                 access_strategy: AccessStrategy::UnknownOrLocal,
+                changes_as_of: None,
             }),
             None => Ok(MirRelationExpr::Get {
                 id: Id::Local(parse_local_id(ident)?),
                 typ: ReprRelationType::empty(),
                 access_strategy: AccessStrategy::UnknownOrLocal,
+                changes_as_of: None,
             }),
         }
     }
@@ -328,6 +330,7 @@ mod relation {
                         id: Id::Local(id),
                         typ,
                         access_strategy: AccessStrategy::UnknownOrLocal,
+                        changes_as_of: None,
                     };
                     // Do not use the `union` smart constructor here!
                     MirRelationExpr::Union {

--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -251,6 +251,7 @@ pub fn enforce_linear_chains(expr: &mut MirRelationExpr) -> Result<(), ExplainEr
                         id: Id::Local(id.clone()),
                         typ: input.typ(),
                         access_strategy: AccessStrategy::UnknownOrLocal,
+                        changes_as_of: None,
                     }),
                 };
                 // swap the current body with the replacement

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -459,6 +459,7 @@ impl MirRelationExpr {
             Get {
                 id,
                 access_strategy: persist_or_index,
+                changes_as_of,
                 ..
             } => {
                 match id {
@@ -527,6 +528,9 @@ impl MirRelationExpr {
                             }
                         }
                     }
+                }
+                if let Some(as_of) = changes_as_of {
+                    write!(f, " changes_as_of={}", as_of)?;
                 }
                 self.fmt_analyses(f, ctx)?;
             }

--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -124,6 +124,11 @@ pub enum MirRelationExpr {
         /// by `prune_and_annotate_dataflow_index_imports`. Note that this is not used by the
         /// lowering to LIR, but is used only by EXPLAIN.
         access_strategy: AccessStrategy,
+        /// If set, this reads the collection's history from the given time onward as an
+        /// append-only collection: one `(row..., mz_timestamp, mz_diff)` row per consolidated
+        /// update, with `typ` describing those promoted rows. Only meaningful for global ids
+        /// backed by a persist shard whose since is pinned at or before the time.
+        changes_as_of: Option<mz_repr::Timestamp>,
     },
     /// Introduce a temporary dataflow.
     ///
@@ -1135,6 +1140,7 @@ impl MirRelationExpr {
             id: Id::Local(id),
             typ,
             access_strategy: AccessStrategy::UnknownOrLocal,
+            changes_as_of: None,
         }
     }
 
@@ -1144,6 +1150,22 @@ impl MirRelationExpr {
             id: Id::Global(id),
             typ,
             access_strategy: AccessStrategy::UnknownOrLocal,
+            changes_as_of: None,
+        }
+    }
+
+    /// Constructs the expression for reading a global collection's history from `as_of` onward
+    /// as promoted `(row..., mz_timestamp, mz_diff)` rows; `typ` must describe those rows.
+    pub fn global_get_changes(
+        id: GlobalId,
+        typ: ReprRelationType,
+        as_of: mz_repr::Timestamp,
+    ) -> Self {
+        MirRelationExpr::Get {
+            id: Id::Global(id),
+            typ,
+            access_strategy: AccessStrategy::UnknownOrLocal,
+            changes_as_of: Some(as_of),
         }
     }
 
@@ -1590,6 +1612,7 @@ impl MirRelationExpr {
                 id: Id::Local(id),
                 typ: self.typ(),
                 access_strategy: AccessStrategy::UnknownOrLocal,
+                changes_as_of: None,
             };
             let body = (body)(id_gen, get)?;
             Ok(MirRelationExpr::Let {
@@ -4210,14 +4233,16 @@ mod structured_diff {
                             id: id1,
                             typ: typ1,
                             access_strategy: as1,
+                            changes_as_of: c1,
                         },
                         MirRelationExpr::Get {
                             id: id2,
                             typ: typ2,
                             access_strategy: as2,
+                            changes_as_of: c2,
                         },
                     ) => {
-                        if id1 != id2 || typ1 != typ2 || as1 != as2 {
+                        if id1 != id2 || typ1 != typ2 || as1 != as2 || c1 != c2 {
                             return Some((expr1, expr2));
                         }
                     }

--- a/src/mz-deploy/src/project/compiler/cache/build_artifact.rs
+++ b/src/mz-deploy/src/project/compiler/cache/build_artifact.rs
@@ -1250,7 +1250,9 @@ impl<'ast> Visit<'ast, Raw> for AliasVisitor<'_> {
 
     fn visit_table_factor(&mut self, node: &'ast TableFactor<Raw>) {
         match node {
-            TableFactor::Table { name, alias } | TableFactor::Changes { name, alias, .. } => {
+            TableFactor::Table { name, alias }
+            | TableFactor::Changes { name, alias, .. }
+            | TableFactor::AsOfSystemTime { name, alias, .. } => {
                 let unresolved = name.name();
                 if unresolved.0.len() == 1 && self.cte_scope.is_cte(&unresolved.0[0].to_string()) {
                     return;

--- a/src/mz-deploy/src/project/compiler/cache/build_artifact.rs
+++ b/src/mz-deploy/src/project/compiler/cache/build_artifact.rs
@@ -1250,7 +1250,7 @@ impl<'ast> Visit<'ast, Raw> for AliasVisitor<'_> {
 
     fn visit_table_factor(&mut self, node: &'ast TableFactor<Raw>) {
         match node {
-            TableFactor::Table { name, alias } => {
+            TableFactor::Table { name, alias } | TableFactor::Changes { name, alias, .. } => {
                 let unresolved = name.name();
                 if unresolved.0.len() == 1 && self.cte_scope.is_cte(&unresolved.0[0].to_string()) {
                     return;

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -84,6 +84,7 @@ Catalog
 Certificate
 Chain
 Chains
+Changes
 Char
 Character
 Characteristics
@@ -360,6 +361,7 @@ Password
 Path
 Pattern
 Physical
+Pin
 Plan
 Plans
 Policies
@@ -451,6 +453,7 @@ Session
 Set
 Shard
 Show
+Since
 Sink
 Sinks
 Size

--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -573,6 +573,13 @@ pub enum TableFactor<T: AstInfo> {
         name: T::ItemName,
         alias: Option<TableAlias>,
     },
+    /// `CHANGES(name AS OF expr)`: the consolidated update history of `name` from the given time
+    /// onward, with `mz_timestamp` and `mz_diff` as trailing columns.
+    Changes {
+        name: T::ItemName,
+        as_of: Expr<T>,
+        alias: Option<TableAlias>,
+    },
     Function {
         function: Function<T>,
         alias: Option<TableAlias>,
@@ -603,6 +610,17 @@ impl<T: AstInfo> AstDisplay for TableFactor<T> {
         match self {
             TableFactor::Table { name, alias } => {
                 f.write_node(name);
+                if let Some(alias) = alias {
+                    f.write_str(" AS ");
+                    f.write_node(alias);
+                }
+            }
+            TableFactor::Changes { name, as_of, alias } => {
+                f.write_str("CHANGES(");
+                f.write_node(name);
+                f.write_str(" AS OF ");
+                f.write_node(as_of);
+                f.write_str(")");
                 if let Some(alias) = alias {
                     f.write_str(" AS ");
                     f.write_node(alias);

--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -580,6 +580,14 @@ pub enum TableFactor<T: AstInfo> {
         as_of: Expr<T>,
         alias: Option<TableAlias>,
     },
+    /// `name AS OF SYSTEM TIME time SINCE since`: the contents of `name` at virtual time `time`,
+    /// which may refer to columns of the enclosing query. `since` bounds the readable history.
+    AsOfSystemTime {
+        name: T::ItemName,
+        time: Expr<T>,
+        since: Expr<T>,
+        alias: Option<TableAlias>,
+    },
     Function {
         function: Function<T>,
         alias: Option<TableAlias>,
@@ -621,6 +629,22 @@ impl<T: AstInfo> AstDisplay for TableFactor<T> {
                 f.write_str(" AS OF ");
                 f.write_node(as_of);
                 f.write_str(")");
+                if let Some(alias) = alias {
+                    f.write_str(" AS ");
+                    f.write_node(alias);
+                }
+            }
+            TableFactor::AsOfSystemTime {
+                name,
+                time,
+                since,
+                alias,
+            } => {
+                f.write_node(name);
+                f.write_str(" AS OF SYSTEM TIME ");
+                f.write_node(time);
+                f.write_str(" SINCE ");
+                f.write_node(since);
                 if let Some(alias) = alias {
                     f.write_str(" AS ");
                     f.write_node(alias);

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -4576,6 +4576,7 @@ pub enum WithOptionValue<T: AstInfo> {
     ConnectionAwsPrivatelink(ConnectionDefaultAwsPrivatelink<T>),
     KafkaMatchingBrokerRule(KafkaMatchingBrokerRule<T>),
     RetainHistoryFor(Value),
+    RetainHistoryPinAt(Value),
     Refresh(RefreshOptionValue<T>),
     ClusterScheduleOptionValue(ClusterScheduleOptionValue),
     ClusterAutoScalingStrategyOptionValue(ClusterAutoScalingStrategyOptionValue),
@@ -4593,6 +4594,7 @@ impl<T: AstInfo> AstDisplay for WithOptionValue<T> {
                 | WithOptionValue::Sequence(_)
                 | WithOptionValue::Map(_)
                 | WithOptionValue::RetainHistoryFor(_)
+                | WithOptionValue::RetainHistoryPinAt(_)
                 | WithOptionValue::Refresh(_)
                 | WithOptionValue::Expr(_) => {
                     // These are redact-aware.
@@ -4673,6 +4675,10 @@ impl<T: AstInfo> AstDisplay for WithOptionValue<T> {
             }
             WithOptionValue::RetainHistoryFor(value) => {
                 f.write_str("FOR ");
+                f.write_node(value);
+            }
+            WithOptionValue::RetainHistoryPinAt(value) => {
+                f.write_str("PIN AT ");
                 f.write_node(value);
             }
             WithOptionValue::Refresh(opt) => f.write_node(opt),

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4290,6 +4290,11 @@ impl<'a> Parser<'a> {
 
     fn parse_retain_history(&mut self) -> Result<WithOptionValue<Raw>, ParserError> {
         let _ = self.consume_token(&Token::Eq);
+        if self.parse_keyword(PIN) {
+            self.expect_keyword(AT)?;
+            let value = self.parse_value()?;
+            return Ok(WithOptionValue::RetainHistoryPinAt(value));
+        }
         self.expect_keyword(FOR)?;
         let value = self.parse_value()?;
         Ok(WithOptionValue::RetainHistoryFor(value))

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -8736,6 +8736,20 @@ impl<'a> Parser<'a> {
                     alias,
                     with_ordinality,
                 })
+            } else if self.peek_keywords(&[AS, OF, SYSTEM, TIME]) {
+                for kw in [AS, OF, SYSTEM, TIME] {
+                    self.expect_keyword(kw)?;
+                }
+                let time = self.parse_expr()?;
+                self.expect_keyword(SINCE)?;
+                let since = self.parse_expr()?;
+                let alias = self.parse_optional_table_alias()?;
+                Ok(TableFactor::AsOfSystemTime {
+                    name,
+                    time,
+                    since,
+                    alias,
+                })
             } else {
                 Ok(TableFactor::Table {
                     name,

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -8710,6 +8710,16 @@ impl<'a> Parser<'a> {
             })
         } else if self.parse_keywords(&[ROWS, FROM]) {
             Ok(self.parse_rows_from()?)
+        } else if self.peek_keyword(CHANGES) && self.peek_nth_token(1) == Some(Token::LParen) {
+            self.expect_keyword(CHANGES)?;
+            self.expect_token(&Token::LParen)?;
+            let name = self.parse_raw_name()?;
+            self.expect_keyword(AS)?;
+            self.expect_keyword(OF)?;
+            let as_of = self.parse_expr()?;
+            self.expect_token(&Token::RParen)?;
+            let alias = self.parse_optional_table_alias()?;
+            Ok(TableFactor::Changes { name, as_of, alias })
         } else {
             let name = self.parse_raw_name()?;
             if self.consume_token(&Token::LParen) {

--- a/src/sql-parser/tests/testdata/create
+++ b/src/sql-parser/tests/testdata/create
@@ -717,3 +717,18 @@ CREATE TABLE t (x int, y text VERSION ADDED '10000')
 error: Expected literal unsigned integer, found string literal "10000"
 CREATE TABLE t (x int, y text VERSION ADDED '10000')
                                             ^
+
+parse-statement roundtrip
+CREATE MATERIALIZED VIEW mv WITH (RETAIN HISTORY = PIN AT 1700000000000) AS SELECT 1
+----
+CREATE MATERIALIZED VIEW mv WITH (RETAIN HISTORY = PIN AT 1700000000000) AS SELECT 1
+
+parse-statement roundtrip
+CREATE TABLE t (a int) WITH (RETAIN HISTORY = PIN AT '2026-09-01 00:00:00')
+----
+CREATE TABLE t (a int4) WITH (RETAIN HISTORY = PIN AT '2026-09-01 00:00:00')
+
+parse-statement roundtrip
+ALTER MATERIALIZED VIEW mv SET (RETAIN HISTORY = PIN AT 1700000000000)
+----
+ALTER MATERIALIZED VIEW mv SET (RETAIN HISTORY PIN AT 1700000000000)

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -2105,3 +2105,23 @@ FROM iffy_colnames
 SELECT "true", "false", "null", "array", "list", map, "case", "cast", coalesce, greatest, least, nullif, exists, extract, "not", row, trim, position, substring FROM iffy_colnames
 =>
 Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("true")]), alias: None }, Expr { expr: Identifier([Ident("false")]), alias: None }, Expr { expr: Identifier([Ident("null")]), alias: None }, Expr { expr: Identifier([Ident("array")]), alias: None }, Expr { expr: Identifier([Ident("list")]), alias: None }, Expr { expr: Identifier([Ident("map")]), alias: None }, Expr { expr: Identifier([Ident("case")]), alias: None }, Expr { expr: Identifier([Ident("cast")]), alias: None }, Expr { expr: Identifier([Ident("coalesce")]), alias: None }, Expr { expr: Identifier([Ident("greatest")]), alias: None }, Expr { expr: Identifier([Ident("least")]), alias: None }, Expr { expr: Identifier([Ident("nullif")]), alias: None }, Expr { expr: Identifier([Ident("exists")]), alias: None }, Expr { expr: Identifier([Ident("extract")]), alias: None }, Expr { expr: Identifier([Ident("not")]), alias: None }, Expr { expr: Identifier([Ident("row")]), alias: None }, Expr { expr: Identifier([Ident("trim")]), alias: None }, Expr { expr: Identifier([Ident("position")]), alias: None }, Expr { expr: Identifier([Ident("substring")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("iffy_colnames")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement roundtrip
+SELECT * FROM CHANGES(mv AS OF 1700000000000)
+----
+SELECT * FROM CHANGES(mv AS OF 1700000000000)
+
+parse-statement roundtrip
+SELECT k, mz_timestamp, mz_diff FROM CHANGES(mv AS OF '2026-09-01 00:00:00') AS c WHERE mz_diff > 0
+----
+SELECT k, mz_timestamp, mz_diff FROM CHANGES(mv AS OF '2026-09-01 00:00:00') AS c WHERE mz_diff > 0
+
+parse-statement roundtrip
+SELECT o.id, p.price FROM orders AS o, LATERAL (SELECT price FROM prices AS OF SYSTEM TIME o.ts SINCE 1700000000000 WHERE prices.sym = o.sym) AS p
+----
+SELECT o.id, p.price FROM orders AS o, LATERAL (SELECT price FROM prices AS OF SYSTEM TIME o.ts SINCE 1700000000000 WHERE prices.sym = o.sym) AS p
+
+parse-statement roundtrip
+SELECT * FROM t AS OF 5
+----
+SELECT * FROM t AS OF 5

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -916,6 +916,11 @@ pub trait CatalogItem {
     /// Returns the cluster the item belongs to.
     fn cluster_id(&self) -> Option<ClusterId>;
 
+    /// The custom history retention policy of the item, if any.
+    fn compaction_window(&self) -> Option<mz_adapter_types::compaction::CompactionWindow> {
+        None
+    }
+
     /// Returns the [`CatalogCollectionItem`] for a specific version of this
     /// [`CatalogItem`].
     fn at_version(&self, version: RelationVersionSelector) -> Box<dyn CatalogCollectionItem>;

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -2213,6 +2213,17 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                 as_of: self.fold_expr(as_of),
                 alias: alias.map(|alias| self.fold_table_alias(alias)),
             },
+            AsOfSystemTime {
+                name,
+                time,
+                since,
+                alias,
+            } => AsOfSystemTime {
+                name: self.fold_item_name(name),
+                time: self.fold_expr(time),
+                since: self.fold_expr(since),
+                alias: alias.map(|alias| self.fold_table_alias(alias)),
+            },
             Function {
                 function,
                 alias,

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -2066,6 +2066,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                 KafkaMatchingBrokerRule(self.fold_kafka_matching_broker_rule(x))
             }
             RetainHistoryFor(value) => RetainHistoryFor(self.fold_value(value)),
+            RetainHistoryPinAt(value) => RetainHistoryPinAt(self.fold_value(value)),
             Refresh(refresh) => Refresh(self.fold_refresh_option_value(refresh)),
             ClusterScheduleOptionValue(value) => ClusterScheduleOptionValue(value),
             ClusterAutoScalingStrategyOptionValue(value) => {

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -2208,6 +2208,11 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                 name: self.fold_item_name(name),
                 alias: alias.map(|alias| self.fold_table_alias(alias)),
             },
+            Changes { name, as_of, alias } => Changes {
+                name: self.fold_item_name(name),
+                as_of: self.fold_expr(as_of),
+                alias: alias.map(|alias| self.fold_table_alias(alias)),
+            },
             Function {
                 function,
                 alias,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -112,7 +112,7 @@ pub use hir::{
 };
 pub use lowering::Config as HirToMirConfig;
 pub use notice::PlanNotice;
-pub use query::{ExprContext, QueryContext, QueryLifetime};
+pub use query::{ExprContext, QueryContext, QueryLifetime, changes_desc};
 pub use scope::Scope;
 pub use side_effecting_func::SideEffectingFunc;
 pub use statement::ddl::{

--- a/src/sql/src/plan/explain.rs
+++ b/src/sql/src/plan/explain.rs
@@ -113,6 +113,7 @@ pub fn normalize_subqueries<'a>(expr: &'a mut HirRelationExpr) {
                         let mut subquery = Get {
                             id: Id::Local(local_id.clone()),
                             typ: SqlRelationType::empty(), // TODO (aalexandrov)
+                            changes_as_of: None,
                         };
                         // swap the current subquery with the replacement
                         std::mem::swap(expr, &mut subquery);

--- a/src/sql/src/plan/hir.rs
+++ b/src/sql/src/plan/hir.rs
@@ -114,6 +114,8 @@ pub enum HirRelationExpr {
     Get {
         id: mz_expr::Id,
         typ: SqlRelationType,
+        /// See `MirRelationExpr::Get::changes_as_of`.
+        changes_as_of: Option<mz_repr::Timestamp>,
     },
     /// Mutually recursive CTE
     LetRec {
@@ -2580,7 +2582,7 @@ impl VisitChildren<Self> for HirRelationExpr {
 
         use HirRelationExpr::*;
         match self {
-            Constant { rows: _, typ: _ } | Get { id: _, typ: _ } => (),
+            Constant { rows: _, typ: _ } | Get { .. } => (),
             Let {
                 name: _,
                 id: _,
@@ -2663,7 +2665,7 @@ impl VisitChildren<Self> for HirRelationExpr {
 
         use HirRelationExpr::*;
         match self {
-            Constant { rows: _, typ: _ } | Get { id: _, typ: _ } => (),
+            Constant { rows: _, typ: _ } | Get { .. } => (),
             Let {
                 name: _,
                 id: _,
@@ -2746,7 +2748,7 @@ impl VisitChildren<Self> for HirRelationExpr {
 
         use HirRelationExpr::*;
         match self {
-            Constant { rows: _, typ: _ } | Get { id: _, typ: _ } => (),
+            Constant { rows: _, typ: _ } | Get { .. } => (),
             Let {
                 name: _,
                 id: _,
@@ -2830,7 +2832,7 @@ impl VisitChildren<Self> for HirRelationExpr {
 
         use HirRelationExpr::*;
         match self {
-            Constant { rows: _, typ: _ } | Get { id: _, typ: _ } => (),
+            Constant { rows: _, typ: _ } | Get { .. } => (),
             Let {
                 name: _,
                 id: _,
@@ -2909,7 +2911,7 @@ impl VisitChildren<Self> for HirRelationExpr {
         let mut v: Vec<&HirRelationExpr> = vec![];
         use HirRelationExpr::*;
         match self {
-            Constant { rows: _, typ: _ } | Get { id: _, typ: _ } => (),
+            Constant { rows: _, typ: _ } | Get { .. } => (),
             Let {
                 name: _,
                 id: _,
@@ -2999,7 +3001,7 @@ impl VisitChildren<Self> for HirRelationExpr {
         let mut v = vec![];
         use HirRelationExpr::*;
         match self {
-            Constant { rows: _, typ: _ } | Get { id: _, typ: _ } => (),
+            Constant { rows: _, typ: _ } | Get { .. } => (),
             Let {
                 name: _,
                 id: _,
@@ -3093,7 +3095,7 @@ impl VisitChildren<HirScalarExpr> for HirRelationExpr {
         use HirRelationExpr::*;
         match self {
             Constant { rows: _, typ: _ }
-            | Get { id: _, typ: _ }
+            | Get { .. }
             | Let {
                 name: _,
                 id: _,
@@ -3170,7 +3172,7 @@ impl VisitChildren<HirScalarExpr> for HirRelationExpr {
         use HirRelationExpr::*;
         match self {
             Constant { rows: _, typ: _ }
-            | Get { id: _, typ: _ }
+            | Get { .. }
             | Let {
                 name: _,
                 id: _,
@@ -3247,7 +3249,7 @@ impl VisitChildren<HirScalarExpr> for HirRelationExpr {
         use HirRelationExpr::*;
         match self {
             Constant { rows: _, typ: _ }
-            | Get { id: _, typ: _ }
+            | Get { .. }
             | Let {
                 name: _,
                 id: _,
@@ -3325,7 +3327,7 @@ impl VisitChildren<HirScalarExpr> for HirRelationExpr {
         use HirRelationExpr::*;
         match self {
             Constant { rows: _, typ: _ }
-            | Get { id: _, typ: _ }
+            | Get { .. }
             | Let {
                 name: _,
                 id: _,
@@ -3403,7 +3405,7 @@ impl VisitChildren<HirScalarExpr> for HirRelationExpr {
         use HirRelationExpr::*;
         match self {
             Constant { rows: _, typ: _ }
-            | Get { id: _, typ: _ }
+            | Get { .. }
             | Let {
                 name: _,
                 id: _,
@@ -3463,7 +3465,7 @@ impl VisitChildren<HirScalarExpr> for HirRelationExpr {
         use HirRelationExpr::*;
         match self {
             Constant { rows: _, typ: _ }
-            | Get { id: _, typ: _ }
+            | Get { .. }
             | Let {
                 name: _,
                 id: _,

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -279,13 +279,18 @@ impl HirRelationExpr {
                         typ: ReprRelationType::from(&typ),
                     })
                 }
-                Get { id, typ } => match id {
+                Get {
+                    id,
+                    typ,
+                    changes_as_of,
+                } => match id {
                     mz_expr::Id::Local(local_id) => {
                         let cte_desc = cte_map.get(&local_id).unwrap();
                         let get_cte = SR::Get {
                             id: mz_expr::Id::Local(cte_desc.new_id.clone()),
                             typ: cte_desc.relation_type.clone(),
                             access_strategy: AccessStrategy::UnknownOrLocal,
+                            changes_as_of: None,
                         };
                         if get_outer == cte_desc.outer_relation {
                             // If the CTE was applied to the same exact relation, we can safely
@@ -339,6 +344,7 @@ impl HirRelationExpr {
                             id,
                             typ: ReprRelationType::from(&typ),
                             access_strategy: AccessStrategy::UnknownOrLocal,
+                            changes_as_of,
                         })
                     }
                 },

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1001,6 +1001,17 @@ where
 
 /// Plans an expression in the AS OF position of a `SELECT` or `SUBSCRIBE`, or `CREATE MATERIALIZED
 /// VIEW` statement.
+/// The relation description of `CHANGES(x AS OF t)` for a collection described by `desc`: its
+/// columns followed by `mz_timestamp` and `mz_diff`, with no keys (a key of `x` is not a key of
+/// its history).
+pub fn changes_desc(desc: &RelationDesc) -> RelationDesc {
+    RelationDesc::builder()
+        .with_columns(desc.iter().map(|(name, typ)| (name.clone(), typ.clone())))
+        .with_column("mz_timestamp", SqlScalarType::MzTimestamp.nullable(false))
+        .with_column("mz_diff", SqlScalarType::Int64.nullable(false))
+        .finish()
+}
+
 pub fn plan_as_of(
     scx: &StatementContext,
     as_of: Option<AsOf<Aug>>,
@@ -3099,6 +3110,12 @@ fn plan_table_factor(
     match table_factor {
         TableFactor::Table { name, alias } => {
             let (expr, scope) = qcx.resolve_table_name(name.clone())?;
+            let scope = plan_table_alias(scope, alias.as_ref())?;
+            Ok((expr, scope))
+        }
+
+        TableFactor::Changes { name, as_of, alias } => {
+            let (expr, scope) = qcx.resolve_changes(name.clone(), as_of)?;
             let scope = plan_table_alias(scope, alias.as_ref())?;
             Ok((expr, scope))
         }
@@ -6864,6 +6881,63 @@ impl<'a> QueryContext<'a> {
 
     /// Resolves `object` to a table expr, i.e. creating a `Get` or inlining a
     /// CTE.
+    /// Plans `CHANGES(object AS OF as_of)`: the object's consolidated update history from `as_of`
+    /// onward, as rows extended with `mz_timestamp` and `mz_diff`.
+    ///
+    /// The object must be backed by a persist shard whose history is pinned (`RETAIN HISTORY PIN
+    /// AT`) at or before `as_of`; the pin is what makes the result a function of the data and
+    /// `as_of` alone rather than of compaction.
+    pub fn resolve_changes(
+        &self,
+        object: ResolvedItemName,
+        as_of: &Expr<Aug>,
+    ) -> Result<(HirRelationExpr, Scope), PlanError> {
+        let ResolvedItemName::Item {
+            id,
+            full_name,
+            version,
+            ..
+        } = object
+        else {
+            sql_bail!("CHANGES requires a table, source, or materialized view");
+        };
+        let entry = self.scx.get_item(&id);
+        match entry.item_type() {
+            CatalogItemType::Table
+            | CatalogItemType::Source
+            | CatalogItemType::MaterializedView => {}
+            other => sql_bail!("CHANGES is not supported on {other} {full_name}"),
+        }
+        let item = entry.at_version(version);
+        let desc = item
+            .relation_desc()
+            .ok_or_else(|| PlanError::InvalidDependency {
+                name: full_name.to_string(),
+                item_type: item.item_type().to_string(),
+            })?
+            .into_owned();
+        let as_of = plan_as_of_or_up_to(self.scx, as_of.clone())?;
+        match entry.compaction_window().and_then(|cw| cw.pinned_from()) {
+            Some(pin) if pin <= as_of => {}
+            Some(pin) => sql_bail!(
+                "CHANGES AS OF {as_of} on {full_name} requires its RETAIN HISTORY PIN AT ({pin}) \
+                 to be at or before the AS OF time"
+            ),
+            None => sql_bail!(
+                "CHANGES requires {full_name} to have RETAIN HISTORY PIN AT at or before {as_of}"
+            ),
+        }
+        let desc = changes_desc(&desc);
+        let expr = HirRelationExpr::Get {
+            id: Id::Global(item.global_id()),
+            typ: desc.typ().clone(),
+            changes_as_of: Some(as_of),
+        };
+        let name = full_name.into();
+        let scope = Scope::from_source(Some(name), desc.iter_names().cloned());
+        Ok((expr, scope))
+    }
+
     pub fn resolve_table_name(
         &self,
         object: ResolvedItemName,
@@ -6888,6 +6962,7 @@ impl<'a> QueryContext<'a> {
                 let expr = HirRelationExpr::Get {
                     id: Id::Global(item.global_id()),
                     typ: desc.typ().clone(),
+                    changes_as_of: None,
                 };
 
                 let name = full_name.into();
@@ -6901,6 +6976,7 @@ impl<'a> QueryContext<'a> {
                 let expr = HirRelationExpr::Get {
                     id: Id::Local(id),
                     typ: cte.desc.typ().clone(),
+                    changes_as_of: None,
                 };
 
                 let scope = Scope::from_source(Some(name), cte.desc.iter_names());

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1001,6 +1001,83 @@ where
 
 /// Plans an expression in the AS OF position of a `SELECT` or `SUBSCRIBE`, or `CREATE MATERIALIZED
 /// VIEW` statement.
+/// Plans `name AS OF SYSTEM TIME time SINCE since` by desugaring it to the correlated query
+///
+/// ```sql
+/// SELECT cols FROM (
+///   SELECT cols, sum(mz_diff) AS c FROM CHANGES(name AS OF since)
+///   WHERE mz_timestamp <= time AND time <= mz_now() GROUP BY cols
+/// ), repeat_row(c)
+/// ```
+///
+/// The contents of `name` at virtual time `time` are the consolidated sum of its changes up to
+/// `time`. A `time` before `since` selects no changes and yields the empty relation, and a `time`
+/// in the future delays the output until then. Definiteness is inherited from CHANGES: with the
+/// history pinned, the result depends only on `time`, `since`, and the data.
+///
+/// Returns the plan, its scope, and the alias to use when the user gave none.
+fn plan_as_of_system_time(
+    qcx: &QueryContext,
+    name: &ResolvedItemName,
+    time: &Expr<Aug>,
+    since: &Expr<Aug>,
+) -> Result<(HirRelationExpr, Scope, TableAlias), PlanError> {
+    let ResolvedItemName::Item {
+        id,
+        full_name,
+        version,
+        ..
+    } = name
+    else {
+        sql_bail!("AS OF SYSTEM TIME requires a table, source, or materialized view");
+    };
+    let item = qcx.scx.get_item(id).at_version(*version);
+    let desc = item
+        .relation_desc()
+        .ok_or_else(|| PlanError::InvalidDependency {
+            name: full_name.to_string(),
+            item_type: item.item_type().to_string(),
+        })?;
+    let cols = desc
+        .iter_names()
+        .map(|n| Ok::<_, PlanError>(Ident::new(n.as_str())?.to_ast_string_stable()))
+        .collect::<Result<Vec<_>, _>>()?
+        .join(", ");
+    let sql = format!(
+        "SELECT {cols} FROM (SELECT {cols}, sum(mz_diff)::pg_catalog.int8 AS __mz_count \
+         FROM CHANGES({name} AS OF {since}) \
+         WHERE mz_timestamp <= ({time}) AND ({time}) <= mz_now() GROUP BY {cols}) AS __mz_history, \
+         mz_catalog.repeat_row(__mz_count)",
+        name = name.to_ast_string_stable(),
+        since = since.to_ast_string_stable(),
+        time = time.to_ast_string_stable(),
+    );
+    let stmt = crate::parse::parse(&sql)
+        .map_err(|e| {
+            PlanError::Unstructured(format!("internal error: AS OF SYSTEM TIME desugaring: {e}"))
+        })?
+        .into_element()
+        .ast;
+    let mz_sql_parser::ast::Statement::Select(mz_sql_parser::ast::SelectStatement {
+        query, ..
+    }) = stmt
+    else {
+        unreachable!("desugared AS OF SYSTEM TIME is a SELECT")
+    };
+    let (mut query, _) = crate::names::resolve(qcx.scx.catalog, query)?;
+    transform_ast::transform(qcx.scx, &mut query)?;
+    // Plan as a LATERAL derived table: `time` may refer to the enclosing scope.
+    let mut qcx = qcx.clone();
+    qcx.outer_scopes[0].lateral_barrier = true;
+    let (expr, scope) = plan_nested_query(&mut qcx, &query)?;
+    let default_alias = TableAlias {
+        name: Ident::new(full_name.item.as_str())?,
+        columns: vec![],
+        strict: false,
+    };
+    Ok((expr, scope, default_alias))
+}
+
 /// The relation description of `CHANGES(x AS OF t)` for a collection described by `desc`: its
 /// columns followed by `mz_timestamp` and `mz_diff`, with no keys (a key of `x` is not a key of
 /// its history).
@@ -3116,6 +3193,18 @@ fn plan_table_factor(
 
         TableFactor::Changes { name, as_of, alias } => {
             let (expr, scope) = qcx.resolve_changes(name.clone(), as_of)?;
+            let scope = plan_table_alias(scope, alias.as_ref())?;
+            Ok((expr, scope))
+        }
+
+        TableFactor::AsOfSystemTime {
+            name,
+            time,
+            since,
+            alias,
+        } => {
+            let (expr, scope, default_alias) = plan_as_of_system_time(qcx, name, time, since)?;
+            let alias = alias.clone().or(Some(default_alias));
             let scope = plan_table_alias(scope, alias.as_ref())?;
             Ok((expr, scope))
         }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -21,6 +21,8 @@ use std::time::Duration;
 use chrono::DateTime;
 use itertools::Itertools;
 use mz_adapter_types::compaction::{CompactionWindow, DEFAULT_LOGICAL_COMPACTION_WINDOW_DURATION};
+
+use crate::plan::with_options::RetainHistoryValue;
 use mz_arrow_util::builder::ArrowBuilder;
 use mz_auth::password::Password;
 use mz_controller_types::{ClusterId, DEFAULT_REPLICA_LOGGING_INTERVAL, ReplicaId};
@@ -537,7 +539,7 @@ pub fn describe_create_subsource(
 generate_extracted_config!(
     CreateSourceOption,
     (TimestampInterval, Duration),
-    (RetainHistory, OptionalDuration)
+    (RetainHistory, RetainHistoryValue)
 );
 
 generate_extracted_config!(
@@ -1586,7 +1588,7 @@ generate_extracted_config!(
     CreateSubsourceOption,
     (Progress, bool, Default(false)),
     (ExternalReference, UnresolvedItemName),
-    (RetainHistory, OptionalDuration),
+    (RetainHistory, RetainHistoryValue),
     (TextColumns, Vec::<Ident>, Default(vec![])),
     (ExcludeColumns, Vec::<Ident>, Default(vec![])),
     (Details, String)
@@ -1749,7 +1751,7 @@ generate_extracted_config!(
     (TextColumns, Vec::<Ident>, Default(vec![])),
     (ExcludeColumns, Vec::<Ident>, Default(vec![])),
     (PartitionBy, Vec<Ident>),
-    (RetainHistory, OptionalDuration),
+    (RetainHistory, RetainHistoryValue),
     (Details, String)
 );
 
@@ -3208,7 +3210,7 @@ generate_extracted_config!(
     MaterializedViewOption,
     (AssertNotNull, Ident, AllowMultiple),
     (PartitionBy, Vec<Ident>),
-    (RetainHistory, OptionalDuration),
+    (RetainHistory, RetainHistoryValue),
     (Refresh, RefreshOptionValue<Aug>, AllowMultiple)
 );
 
@@ -6488,12 +6490,17 @@ pub fn plan_drop_owned(
 
 fn plan_retain_history_option(
     scx: &StatementContext,
-    retain_history: Option<OptionalDuration>,
+    retain_history: Option<RetainHistoryValue>,
 ) -> Result<Option<CompactionWindow>, PlanError> {
-    if let Some(OptionalDuration(lcw)) = retain_history {
-        Ok(Some(plan_retain_history(scx, lcw)?))
-    } else {
-        Ok(None)
+    match retain_history {
+        Some(RetainHistoryValue::For(OptionalDuration(lcw))) => {
+            Ok(Some(plan_retain_history(scx, lcw)?))
+        }
+        Some(RetainHistoryValue::PinAt(ts)) => {
+            scx.require_feature_flag(&vars::ENABLE_LOGICAL_COMPACTION_WINDOW)?;
+            Ok(Some(CompactionWindow::PinAt(ts)))
+        }
+        None => Ok(None),
     }
 }
 
@@ -6547,7 +6554,7 @@ fn plan_retain_history(
     }
 }
 
-generate_extracted_config!(IndexOption, (RetainHistory, OptionalDuration));
+generate_extracted_config!(IndexOption, (RetainHistory, RetainHistoryValue));
 
 fn plan_index_options(
     scx: &StatementContext,
@@ -6570,7 +6577,7 @@ fn plan_index_options(
 generate_extracted_config!(
     TableOption,
     (PartitionBy, Vec<Ident>),
-    (RetainHistory, OptionalDuration),
+    (RetainHistory, RetainHistoryValue),
     (RedactedTest, String)
 );
 
@@ -7542,16 +7549,28 @@ fn alter_retain_history(
             }
 
             // Save the original value so we can write it back down in the create_sql catalog item.
-            let (value, lcw) = match &history {
+            let (value, window) = match &history {
                 Some(WithOptionValue::RetainHistoryFor(value)) => {
                     let window = OptionalDuration::try_from_value(value.clone())?;
-                    (Some(value.clone()), window.0)
+                    (Some(value.clone()), plan_retain_history(scx, window.0)?)
+                }
+                Some(WithOptionValue::RetainHistoryPinAt(value)) => {
+                    let RetainHistoryValue::PinAt(ts) = RetainHistoryValue::try_from_value(
+                        WithOptionValue::<Aug>::RetainHistoryPinAt(value.clone()),
+                    )?
+                    else {
+                        unreachable!("PIN AT values plan to RetainHistoryValue::PinAt")
+                    };
+                    scx.require_feature_flag(&vars::ENABLE_LOGICAL_COMPACTION_WINDOW)?;
+                    (Some(value.clone()), CompactionWindow::PinAt(ts))
                 }
                 // None is RESET, so use the default CW.
-                None => (None, Some(DEFAULT_LOGICAL_COMPACTION_WINDOW_DURATION)),
+                None => (
+                    None,
+                    plan_retain_history(scx, Some(DEFAULT_LOGICAL_COMPACTION_WINDOW_DURATION))?,
+                ),
                 _ => sql_bail!("unexpected value type for RETAIN HISTORY"),
             };
-            let window = plan_retain_history(scx, lcw)?;
 
             Ok(Plan::AlterRetainHistory(AlterRetainHistoryPlan {
                 id: entry.id(),

--- a/src/sql/src/plan/with_options.rs
+++ b/src/sql/src/plan/with_options.rs
@@ -464,6 +464,56 @@ impl ImpliedValue for OptionalDuration {
     }
 }
 
+/// The value of a `RETAIN HISTORY` option: a duration to lag the write frontier by, or a fixed
+/// time from which history is retained.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RetainHistoryValue {
+    For(OptionalDuration),
+    PinAt(mz_repr::Timestamp),
+}
+
+impl<T: AstInfo + std::fmt::Debug> TryFromValue<WithOptionValue<T>> for RetainHistoryValue {
+    fn try_from_value(v: WithOptionValue<T>) -> Result<Self, PlanError> {
+        match v {
+            WithOptionValue::RetainHistoryPinAt(value) => {
+                let s = match value {
+                    Value::Number(n) => n,
+                    Value::String(s) => s,
+                    other => sql_bail!("invalid RETAIN HISTORY PIN AT value: {other:?}"),
+                };
+                let ts = s.parse::<mz_repr::Timestamp>().map_err(|e| {
+                    PlanError::Unstructured(format!("invalid RETAIN HISTORY PIN AT value: {e}"))
+                })?;
+                Ok(RetainHistoryValue::PinAt(ts))
+            }
+            v => Ok(RetainHistoryValue::For(OptionalDuration::try_from_value(
+                v,
+            )?)),
+        }
+    }
+
+    fn try_into_value(self, catalog: &dyn SessionCatalog) -> Option<WithOptionValue<T>> {
+        match self {
+            RetainHistoryValue::For(d) => Some(WithOptionValue::RetainHistoryFor(
+                d.try_into_value(catalog)?,
+            )),
+            RetainHistoryValue::PinAt(ts) => Some(WithOptionValue::RetainHistoryPinAt(
+                Value::Number(ts.to_string()),
+            )),
+        }
+    }
+
+    fn name() -> String {
+        "retain history value".to_string()
+    }
+}
+
+impl ImpliedValue for RetainHistoryValue {
+    fn implied_value() -> Result<Self, PlanError> {
+        sql_bail!("must provide a RETAIN HISTORY value")
+    }
+}
+
 impl TryFromValue<Value> for String {
     fn try_from_value(v: Value) -> Result<Self, PlanError> {
         match v {
@@ -724,7 +774,8 @@ impl<V: TryFromValue<Value>, T: AstInfo + std::fmt::Debug> TryFromValue<WithOpti
             }
             WithOptionValue::Ident(v) => V::try_from_value(Value::String(v.into_string())),
             WithOptionValue::RetainHistoryFor(v) => V::try_from_value(v),
-            WithOptionValue::Sequence(_)
+            WithOptionValue::RetainHistoryPinAt(_)
+            | WithOptionValue::Sequence(_)
             | WithOptionValue::Map(_)
             | WithOptionValue::Item(_)
             | WithOptionValue::UnresolvedItemName(_)
@@ -745,6 +796,7 @@ impl<V: TryFromValue<Value>, T: AstInfo + std::fmt::Debug> TryFromValue<WithOpti
                     // The first few are unreachable because they are handled at the top of the outer match.
                     WithOptionValue::Value(_) => unreachable!(),
                     WithOptionValue::RetainHistoryFor(_) => unreachable!(),
+                    WithOptionValue::RetainHistoryPinAt(_) => "retain history pins",
                     WithOptionValue::ClusterAlterStrategy(_) => "cluster alter strategy",
                     WithOptionValue::Sequence(_) => "sequences",
                     WithOptionValue::Map(_) => "maps",

--- a/src/transform/src/analysis.rs
+++ b/src/transform/src/analysis.rs
@@ -1054,7 +1054,7 @@ mod column_names {
                 Get {
                     id: Id::Global(id),
                     typ,
-                    access_strategy: _,
+                    ..
                 } => {
                     // Emit ColumnName::Global instances for each column in the
                     // `Get` type. Those can be resolved to real names later when an
@@ -1066,7 +1066,7 @@ mod column_names {
                 Get {
                     id: Id::Local(id),
                     typ,
-                    access_strategy: _,
+                    ..
                 } => {
                     let index_child = *depends.bindings().get(id).expect("id in scope");
                     if index_child < results.len() {

--- a/src/transform/src/cse/anf.rs
+++ b/src/transform/src/cse/anf.rs
@@ -305,6 +305,7 @@ impl Bindings {
                     id: Id::Local(LocalId::new(*id)),
                     typ,
                     access_strategy: AccessStrategy::UnknownOrLocal,
+                    changes_as_of: None,
                 }
             }
 

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -369,6 +369,10 @@ fn optimize_dataflow_filters(dataflow: &mut DataflowDesc) -> Result<(), Transfor
     // Push predicate information into the SourceDesc.
     for (source_id, source_import) in dataflow.source_imports.iter_mut() {
         let source = &mut source_import.desc;
+        // A CHANGES import's rows differ from the shard's rows, so nothing can be pushed into it.
+        if source.arguments.changes_as_of.is_some() {
+            continue;
+        }
         if let Some(list) = predicates.remove(&Id::Global(*source_id)) {
             if !list.is_empty() {
                 // Canonicalize the order of predicates, for stable plans.
@@ -744,6 +748,7 @@ id: {}, key: {:?}",
                         id: Id::Global(global_id),
                         typ: _,
                         access_strategy: persist_or_index,
+                        ..
                     } => {
                         if let Some(new_idx_id) = full_scan_changes.get(global_id) {
                             match persist_or_index {
@@ -834,6 +839,7 @@ id: {}, key: {:?}",
                     id: Id::Global(global_id),
                     typ: _,
                     access_strategy,
+                    ..
                 } => match access_strategy {
                     AccessStrategy::Persist => {
                         if objects_to_build_ids.contains(global_id) {
@@ -856,6 +862,7 @@ id: {}, key: {:?}",
                     id: Id::Global(_),
                     typ: _,
                     access_strategy: AccessStrategy::Index(accesses),
+                    ..
                 } => {
                     for (idx_id, _) in accesses {
                         soft_assert_or_log!(
@@ -1048,6 +1055,19 @@ impl<'a> CollectIndexRequests<'a> {
                 MirRelationExpr::ArrangeBy { input, keys } => {
                     let ctx = &IndexUsageContext::add_keys(contexts, keys);
                     this.collect_index_reqs_inner(input, ctx)?;
+                }
+                MirRelationExpr::Get {
+                    id: Id::Global(global_id),
+                    access_strategy: persist_or_index,
+                    changes_as_of: Some(_),
+                    ..
+                } => {
+                    // A CHANGES read always comes from the persist shard: it needs the shard's
+                    // pinned history, which an index does not durably hold.
+                    this.index_reqs_by_id
+                        .entry(*global_id)
+                        .or_insert_with(Vec::new);
+                    *persist_or_index = AccessStrategy::Persist;
                 }
                 MirRelationExpr::Get {
                     id: Id::Global(global_id),
@@ -1472,6 +1492,7 @@ mod tests {
             id: Id::Global(id),
             typ: typ(),
             access_strategy: AccessStrategy::Persist,
+            changes_as_of: None,
         }
     }
 

--- a/src/transform/src/movement/projection_lifting.rs
+++ b/src/transform/src/movement/projection_lifting.rs
@@ -77,12 +77,14 @@ impl ProjectionLifting {
                     id,
                     typ: _,
                     access_strategy: _,
+                    changes_as_of,
                 } => {
                     if let Some((typ, columns)) = gets.get(id) {
                         *relation = MirRelationExpr::Get {
                             id: *id,
                             typ: typ.clone(),
                             access_strategy: AccessStrategy::UnknownOrLocal, // (we are not copying it over)
+                            changes_as_of: *changes_as_of,
                         }
                         .project(columns.clone());
                     }

--- a/src/transform/src/movement/projection_pushdown.rs
+++ b/src/transform/src/movement/projection_pushdown.rs
@@ -502,6 +502,7 @@ impl ProjectionPushdown {
                     id: inner_id,
                     typ,
                     access_strategy: _,
+                    ..
                 } = &mut **input
                 {
                     if let Some((new_projection, new_type)) = applied_projections.get(inner_id) {


### PR DESCRIPTION
**Draft, PR 3 of 3**, stacked on #38749 (`CHANGES`). Until the earlier PRs merge this diff includes their commits; review the last commit. **This one is a reference implementation for discussion, not a merge candidate.**

### What it does

```sql
SELECT o.id, p.price
FROM orders o
LEFT JOIN LATERAL (
  SELECT price FROM prices AS OF SYSTEM TIME o.ts SINCE 1788538608103
  WHERE prices.sym = o.sym
) p ON true;
```

`x AS OF SYSTEM TIME expr SINCE lit` is a table factor whose `expr` may refer to the enclosing query: the contents of `x` at virtual time `expr`. Each order sees the price at its own time, and that value never moves afterwards. A time before `lit` yields the empty relation (NULL under a LEFT JOIN), a future time delays the row until then, and replicas and restarts agree because `x`'s history is pinned.

### How, and why it is a reference implementation

It desugars to a correlated query over `CHANGES` and is planned as a LATERAL derived table:

```sql
SELECT cols FROM (
  SELECT cols, sum(mz_diff)::bigint AS c FROM CHANGES(x AS OF lit)
  WHERE mz_timestamp <= expr AND expr <= mz_now() GROUP BY cols
), repeat_row(c)
```

That is the definition of "the state at `t`" as the integral of the changelog up to `t`, so the semantics are inherited from `CHANGES` rather than specified twice, and the two features cannot disagree about what history means. It also gives a differential-test oracle for the operator this should become.

The cost is the problem. As a relational join plus reduce, the plan arranges the facts (twice) and keeps one accumulator per (fact, dimension value it scanned), so state grows with facts times versions. A one-sided lookup does not need any of that: the output for (key, t) depends only on the dimension's history at or before t, which is frozen once the dimension's frontier passes t, so a fact can be looked up once and forgotten (retractions recompute the same value from the pinned history). `differential_dogs3::operators::half_join` already stashes records until the arrangement frontier passes them and compares trace times against a per-record time; the variant needed compares against the payload time (for late facts), emits at `max(capability, payload time)`, and accumulates per key at discharge so it can emit the NULL row. The planner would lower the correlated shape to that operator instead of decorrelating. State becomes proportional to the dimension's history since the pin plus facts still waiting for their time.

### Evidence (local instance)

- Orders at three times against a price sequence 1 -> 2 -> 3 got 1, 2, 3; an order before the pin got NULL; an order an hour in the future was withheld and later appeared with the value at its time. Bumping every price by 100 six days later changed none of the existing rows; a new order saw 103.
- Against a hand-written SCD-2 lookup (`ORDER BY ts DESC LIMIT 1` over an explicit history table) on 10k orders and a 21k-row history: identical results, comparable one-shot latency, one third of the arrangement memory (194k vs 590k records). The dedicated operator would sit near orders plus history, about 31k.
- Materialized, one-shot, and both across a restart: identical.

### Things to discuss

- Where the AS OF sits: on the table factor (this PR) or on the subquery (`SELECT dim.val AS OF facts.time ... FROM dim`). Equivalent for one input; the subquery form is friendlier, the table-factor form composes per input.
- `SINCE lit` versus `AT LEAST lit`, and whether a time below the pin yields empty (this PR, per the design note) or clamps to the snapshot at the pin. One token in the desugared predicate either way.
- The `SINCE` literal is baked into each dependent, so advancing retention means recreating dependents with a later literal before the pin can move.
- Desugaring goes through SQL text and `repeat_row`, which sits behind `enable_repeat_row`; a real implementation would build HIR directly.

### Tests

Parser round-trip cases in `src/sql-parser/tests/testdata/select` and `create`.

Release note: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
