### PR TITLE
ci: ignore the state and chart artifacts the Terraform tests produce

### DIFF
--- a/test/terraform/.gitignore
+++ b/test/terraform/.gitignore
@@ -1,12 +1,6 @@
 .terraform.lock.hcl
 .terraform
-terraform.tfvars
-
-# Any state file, not just the two exact names: a state carries the database
-# password and the license key, so a suffixed copy must not be committable.
 terraform.tfstate
 terraform.tfstate.*
-
-# `setup` builds this into the root with `helm package`, so it is untracked in
-# every working tree that has run the test.
+terraform.tfvars
 materialize-operator-*.tgz

--- a/test/terraform/.gitignore
+++ b/test/terraform/.gitignore
@@ -1,5 +1,12 @@
 .terraform.lock.hcl
 .terraform
-terraform.tfstate
-terraform.tfstate.backup
 terraform.tfvars
+
+# Any state file, not just the two exact names: a state carries the database
+# password and the license key, so a suffixed copy must not be committable.
+terraform.tfstate
+terraform.tfstate.*
+
+# `setup` builds this into the root with `helm package`, so it is untracked in
+# every working tree that has run the test.
+materialize-operator-*.tgz


### PR DESCRIPTION
`test/terraform/.gitignore` listed `terraform.tfstate` and `terraform.tfstate.backup` by exact name, so any other suffixed copy was committable. That matters more than it looks: a state for these roots carries the RDS password and the license key, and both Terraform itself (`-state-out` backups) and anyone taking a copy before a manual destroy produce differently suffixed names. `terraform.tfstate.*` covers those and makes the `.backup` line redundant.

Also ignores `materialize-operator-*.tgz`. `AWS.setup` builds it into the root with `helm package`, so it shows up untracked in every working tree that has run the test, which is how it ends up swept into an unrelated commit by a broad `git add`.

Nothing tracked changes: neither a state file nor a tfvars file is in the index today.

### Test plan

`git check-ignore -v` matches both a suffixed state file and the packaged chart, and `git status` in a working tree that has run the test is clean afterwards. Behaviour of the tests themselves is untouched, so this branch doubles as a trigger reference for a Nightly confirming the recent terraform work on main: the branch name matches the AWS jobs' `*terraform*` filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)