### PR TITLE
storage: write the persist source's decode straight into columns

### DIFF
--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -110,7 +110,7 @@ use std::rc::{Rc, Weak};
 use std::sync::Arc;
 use std::task::Poll;
 
-use ::columnar::{Columnar as ColumnarData, Push as ColumnarPush};
+use ::columnar::{Columnar as ColumnarData, Index as ColumnarIndex, Push as ColumnarPush};
 use differential_dataflow::dynamic::pointstamp::PointStamp;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::Arranged;
@@ -293,22 +293,24 @@ pub fn build_compute_dataflow(
 
                     // Note: For correctness, we require that sources only emit times advanced by
                     // `dataflow.as_of`. `persist_source` is documented to provide this guarantee.
-                    let (mut ok_stream, err_stream, token) =
-                        persist_source::persist_source::<DataflowErrorSer>(
-                            inner,
-                            *source_id,
-                            Arc::clone(&compute_state.persist_clients),
-                            &compute_state.txns_ctx,
-                            import.desc.storage_metadata.clone(),
-                            read_schema,
-                            dataflow.as_of.clone(),
-                            snapshot_mode,
-                            until.clone(),
-                            mfp.as_mut(),
-                            compute_state.dataflow_max_inflight_bytes(),
-                            start_signal.clone().into_send_future(),
-                            ErrorHandler::Halt("compute_import"),
-                        );
+                    let (mut ok_stream, err_stream, token) = persist_source::persist_source::<
+                        DataflowErrorSer,
+                        ConsolidatingColumnBuilder<Row, mz_repr::Timestamp, Diff>,
+                    >(
+                        inner,
+                        *source_id,
+                        Arc::clone(&compute_state.persist_clients),
+                        &compute_state.txns_ctx,
+                        import.desc.storage_metadata.clone(),
+                        read_schema,
+                        dataflow.as_of.clone(),
+                        snapshot_mode,
+                        until.clone(),
+                        mfp.as_mut(),
+                        compute_state.dataflow_max_inflight_bytes(),
+                        start_signal.clone().into_send_future(),
+                        ErrorHandler::Halt("compute_import"),
+                    );
 
                     // If `mfp` is non-identity, we need to apply what remains.
                     // For the moment, assert that it is either trivial or `None`.
@@ -378,10 +380,8 @@ pub fn build_compute_dataflow(
                 );
 
                 for (id, (oks, errs)) in imported_sources.into_iter() {
-                    // Persist batches are row-shaped and already consolidated, so the
-                    // encode here is non-consolidating.
                     let bundle = crate::render::CollectionBundle::from_edge(
-                        vec_to_columnar(oks.enter(region)),
+                        oks.enter(region),
                         errs.enter(region),
                     );
                     // Associate collection bundle with the source identifier.
@@ -480,10 +480,8 @@ pub fn build_compute_dataflow(
                 );
 
                 for (id, (oks, errs)) in imported_sources.into_iter() {
-                    // Persist batches are row-shaped and already consolidated, so the
-                    // encode here is non-consolidating.
                     let bundle = crate::render::CollectionBundle::from_edge(
-                        vec_to_columnar(oks.enter_region(region)),
+                        oks.enter_region(region),
                         errs.enter_region(region),
                     );
                     // Associate collection bundle with the source identifier.
@@ -1940,7 +1938,7 @@ fn suppress_early_progress<'scope, T: Timestamp, D>(
     as_of: Antichain<T>,
 ) -> Stream<'scope, T, D>
 where
-    D: Data + timely::Container,
+    D: timely::Container + Clone,
 {
     stream.unary_frontier(Pipeline, "SuppressEarlyProgress", |default_cap, _info| {
         let mut early_cap = Some(default_cap);
@@ -2007,13 +2005,44 @@ trait LimitProgress<T: Timestamp> {
     ) -> Self;
 }
 
+/// Reads the times of the records a container holds, for [`LimitProgress`].
+trait RecordTimes {
+    /// Call `f` once per record, with that record's time.
+    fn for_each_time(&self, f: impl FnMut(mz_repr::Timestamp));
+}
+
+impl<D, R> RecordTimes for Vec<(D, mz_repr::Timestamp, R)> {
+    fn for_each_time(&self, mut f: impl FnMut(mz_repr::Timestamp)) {
+        for (_, time, _) in self {
+            f(*time);
+        }
+    }
+}
+
+impl<D, R> RecordTimes for Column<(D, mz_repr::Timestamp, R)>
+where
+    D: ColumnarData,
+    R: ColumnarData,
+    (D, mz_repr::Timestamp, R): ColumnarData<
+        Container = (
+            D::Container,
+            <mz_repr::Timestamp as ColumnarData>::Container,
+            R::Container,
+        ),
+    >,
+{
+    fn for_each_time(&self, mut f: impl FnMut(mz_repr::Timestamp)) {
+        for time in self.borrow().1.into_index_iter() {
+            f(time);
+        }
+    }
+}
+
 // TODO: We could make this generic over a `T` that can be converted to and from a u64 millisecond
 // number.
-impl<'scope, D, R> LimitProgress<mz_repr::Timestamp>
-    for StreamVec<'scope, mz_repr::Timestamp, (D, mz_repr::Timestamp, R)>
+impl<'scope, C> LimitProgress<mz_repr::Timestamp> for Stream<'scope, mz_repr::Timestamp, C>
 where
-    D: Clone + 'static,
-    R: Clone + 'static,
+    C: timely::Container + Clone + RecordTimes,
 {
     fn limit_progress(
         self,
@@ -2036,10 +2065,10 @@ where
 
                 move |(input, frontier), output| {
                     input.for_each(|cap, data| {
-                        for time in data
-                            .iter()
-                            .flat_map(|(_, time, _)| u64::from(time).checked_add(slack_ms))
-                        {
+                        data.for_each_time(|time| {
+                            let Some(time) = u64::from(time).checked_add(slack_ms) else {
+                                return;
+                            };
                             // `slack_ms == 0` means no rounding; otherwise round up to the next
                             // multiple of `slack_ms`. Avoids a divide-by-zero panic when the
                             // operator is configured without slack.
@@ -2051,7 +2080,7 @@ where
                             if !upper.less_than(&rounded_time.into()) {
                                 pending_times.insert(rounded_time.into());
                             }
-                        }
+                        });
                         output.session(&cap).give_container(data);
                         if retained_cap.as_ref().is_none_or(|c| {
                             !c.time().less_than(cap.time()) && !upper.less_than(cap.time())

--- a/src/compute/src/sink/materialized_view.rs
+++ b/src/compute/src/sink/materialized_view.rs
@@ -409,22 +409,24 @@ pub(super) fn persist_source<'s>(
     let until = Antichain::new();
     let map_filter_project = None;
 
-    let (ok_stream, err_stream, token) =
-        mz_storage_operators::persist_source::persist_source::<DataflowErrorSer>(
-            scope,
-            sink_id,
-            Arc::clone(&compute_state.persist_clients),
-            &compute_state.txns_ctx,
-            target,
-            None,
-            as_of,
-            SnapshotMode::Include,
-            until,
-            map_filter_project,
-            compute_state.dataflow_max_inflight_bytes(),
-            start_signal.into_send_future(),
-            ErrorHandler::Halt("compute persist sink"),
-        );
+    let (ok_stream, err_stream, token) = mz_storage_operators::persist_source::persist_source::<
+        DataflowErrorSer,
+        mz_storage_operators::persist_source::RowVecBuilder<Timestamp>,
+    >(
+        scope,
+        sink_id,
+        Arc::clone(&compute_state.persist_clients),
+        &compute_state.txns_ctx,
+        target,
+        None,
+        as_of,
+        SnapshotMode::Include,
+        until,
+        map_filter_project,
+        compute_state.dataflow_max_inflight_bytes(),
+        start_signal.into_send_future(),
+        ErrorHandler::Halt("compute persist sink"),
+    );
 
     let streams = OkErr::new(ok_stream, err_stream);
     (streams, token)

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -10,13 +10,15 @@
 //! A source that reads from an a persist shard.
 
 use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
+use std::borrow::Cow;
+use std::collections::VecDeque;
 use std::convert::Infallible;
 use std::fmt::Debug;
 use std::future::Future;
 use std::hash::Hash;
 use std::sync::Arc;
-use std::time::Instant;
 
+use differential_dataflow::AsCollection;
 use differential_dataflow::lattice::Lattice;
 use futures::{StreamExt, future::Either};
 use mz_expr::{ColumnSpecs, EvalError, Interpreter, MfpPlan, ResultSpec, UnmaterializableFunc};
@@ -46,14 +48,13 @@ use mz_timely_util::builder_async::{
     Event, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
 };
 use mz_timely_util::probe::ProbeNotify;
-use mz_txn_wal::operator::{TxnsContext, txns_progress};
+use mz_txn_wal::operator::{TxnsContext, TxnsProgress};
 use serde::{Deserialize, Serialize};
-use timely::PartialOrder;
-use timely::container::CapacityContainerBuilder;
+use timely::container::{CapacityContainerBuilder, PushInto};
 use timely::dataflow::channels::pact::Pipeline;
+use timely::dataflow::operators::generic::OutputBuilder;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
-use timely::dataflow::operators::generic::{OutputBuilder, OutputBuilderSession};
-use timely::dataflow::operators::{Capability, Leave, OkErr};
+use timely::dataflow::operators::{Capability, Leave};
 use timely::dataflow::operators::{CapabilitySet, ConnectLoop, Feedback};
 use timely::dataflow::{Scope, Stream, StreamVec};
 use timely::order::TotalOrder;
@@ -61,6 +62,7 @@ use timely::progress::Antichain;
 use timely::progress::Timestamp as TimelyTimestamp;
 use timely::progress::timestamp::PathSummary;
 use timely::scheduling::Activator;
+use timely::{ContainerBuilder, PartialOrder};
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{error, trace};
 
@@ -147,6 +149,8 @@ impl Subtime {
 /// Creates a new source that reads from a persist shard, distributing the work
 /// of reading data to all timely workers.
 ///
+/// Returns the shard's rows in `CB`'s containers and its errors in a stream of their own.
+///
 /// All times emitted will have been [advanced by] the given `as_of` frontier.
 /// All updates at times greater or equal to `until` will be suppressed.
 /// The `map_filter_project` argument, if supplied, may be partially applied,
@@ -166,7 +170,7 @@ impl Subtime {
 /// using [`timely::dataflow::operators::generic::operator::empty`].
 ///
 /// [advanced by]: differential_dataflow::lattice::Lattice::advance_by
-pub fn persist_source<'scope, E>(
+pub fn persist_source<'scope, E, CB>(
     scope: Scope<'scope, mz_repr::Timestamp>,
     source_id: GlobalId,
     persist_clients: Arc<PersistClientCache>,
@@ -181,113 +185,133 @@ pub fn persist_source<'scope, E>(
     start_signal: impl Future<Output = ()> + Send + 'static,
     error_handler: ErrorHandler,
 ) -> (
-    StreamVec<'scope, mz_repr::Timestamp, (Row, Timestamp, Diff)>,
+    Stream<'scope, mz_repr::Timestamp, CB::Container>,
     StreamVec<'scope, mz_repr::Timestamp, (E, Timestamp, Diff)>,
     Vec<PressOnDropButton>,
 )
 where
     E: timely::ExchangeData + Ord + Clone + Debug + From<DataflowError> + From<EvalError>,
+    CB: ContainerBuilder + PushInto<(Row, mz_repr::Timestamp, Diff)>,
+    CB::Container: Clone,
 {
     let mut tokens = vec![];
+    let name = source_id.to_string();
 
     let outer = scope.clone();
-    let stream = scope.scoped(&format!("granular_backpressure({})", source_id), |scope| {
-        let (flow_control, flow_control_probe) = match max_inflight_bytes {
-            Some(max_inflight_bytes) => {
-                let series = &persist_clients.metrics().backpressure;
-                let backpressure_metrics = BackpressureOperatorMetrics::new(
-                    series.emitted_bytes.clone(),
-                    series.last_backpressured_bytes.clone(),
-                    series.retired_bytes.clone(),
-                );
+    let (ok_stream, err_stream) =
+        scope.scoped(&format!("granular_backpressure({})", source_id), |scope| {
+            let (flow_control, flow_control_probe) = match max_inflight_bytes {
+                Some(max_inflight_bytes) => {
+                    let series = &persist_clients.metrics().backpressure;
+                    let backpressure_metrics = BackpressureOperatorMetrics::new(
+                        series.emitted_bytes.clone(),
+                        series.last_backpressured_bytes.clone(),
+                        series.retired_bytes.clone(),
+                    );
 
-                let probe = mz_timely_util::probe::Handle::default();
-                let progress_stream = mz_timely_util::probe::source(
-                    scope.clone(),
-                    format!("decode_backpressure_probe({source_id})"),
-                    probe.clone(),
-                );
-                let flow_control = FlowControl {
-                    progress_stream,
-                    max_inflight_bytes,
-                    summary: (Default::default(), Subtime::least_summary()),
-                    metrics: Some(backpressure_metrics),
-                };
-                (Some(flow_control), Some(probe))
-            }
-            None => (None, None),
-        };
+                    let probe = mz_timely_util::probe::Handle::default();
+                    let progress_stream = mz_timely_util::probe::source(
+                        scope.clone(),
+                        format!("decode_backpressure_probe({source_id})"),
+                        probe.clone(),
+                    );
+                    let flow_control = FlowControl {
+                        progress_stream,
+                        max_inflight_bytes,
+                        summary: (Default::default(), Subtime::least_summary()),
+                        metrics: Some(backpressure_metrics),
+                    };
+                    (Some(flow_control), Some(probe))
+                }
+                None => (None, None),
+            };
 
-        // Our default listen sleeps are tuned for the case of a shard that is
-        // written once a second, but txn-wal allows these to be lazy.
-        // Override the tuning to reduce crdb load. The pubsub fallback
-        // responsibility is then replaced by manual "one state" wakeups in the
-        // txns_progress operator.
-        let cfg = Arc::clone(&persist_clients.cfg().configs);
-        let subscribe_sleep = match metadata.txns_shard {
-            Some(_) => Some(move || mz_txn_wal::operator::txns_data_shard_retry_params(&cfg)),
-            None => None,
-        };
+            // Our default listen sleeps are tuned for the case of a shard that is
+            // written once a second, but txn-wal allows these to be lazy.
+            // Override the tuning to reduce crdb load. The pubsub fallback
+            // responsibility is then replaced by manual "one state" wakeups in the
+            // txns_progress operator.
+            let cfg = Arc::clone(&persist_clients.cfg().configs);
+            let subscribe_sleep = match metadata.txns_shard {
+                Some(_) => Some(move || mz_txn_wal::operator::txns_data_shard_retry_params(&cfg)),
+                None => None,
+            };
 
-        let (stream, source_tokens) = persist_source_core(
-            outer,
-            scope,
-            source_id,
-            Arc::clone(&persist_clients),
-            metadata.clone(),
-            read_schema,
-            as_of.clone(),
-            snapshot_mode,
-            until.clone(),
-            map_filter_project,
-            flow_control,
-            subscribe_sleep,
-            start_signal,
-            error_handler,
-        );
-        tokens.extend(source_tokens);
+            let filter_plan = map_filter_project.as_ref().map(|p| (*p).clone());
+            let (cfg, fetched, source_tokens) = fetch_parts(
+                outer,
+                scope,
+                source_id,
+                Arc::clone(&persist_clients),
+                metadata.clone(),
+                read_schema,
+                as_of.clone(),
+                snapshot_mode,
+                until.clone(),
+                filter_plan,
+                flow_control,
+                subscribe_sleep,
+                start_signal,
+                error_handler,
+            );
+            tokens.extend(source_tokens);
 
-        let stream = match flow_control_probe {
-            Some(probe) => stream.probe_notify_with(vec![probe]),
-            None => stream,
-        };
+            let (ok_stream, err_stream) = decode_and_mfp::<E, mz_repr::Timestamp, CB>(
+                cfg,
+                fetched,
+                &name,
+                until.clone(),
+                map_filter_project,
+                |time| time.0,
+            );
 
-        stream.leave(outer)
-    });
+            // The handle's frontier is the meet of what its clones report, so both streams
+            // have to feed it for backpressure to retire the right bytes.
+            let (ok_stream, err_stream) = match flow_control_probe {
+                Some(probe) => (
+                    ok_stream.probe_notify_with(vec![probe.clone()]),
+                    err_stream.probe_notify_with(vec![probe]),
+                ),
+                None => (ok_stream, err_stream),
+            };
+
+            (ok_stream.leave(outer), err_stream.leave(outer))
+        });
 
     // If a txns_shard was provided, then this shard is in the txn-wal
     // system. This means the "logical" upper may be ahead of the "physical"
-    // upper. Render a dataflow operator that passes through the input and
-    // translates the progress frontiers as necessary.
-    let (stream, txns_tokens) = match metadata.txns_shard {
-        Some(txns_shard) => txns_progress::<SourceData, (), Timestamp, i64, _, TxnsCodecRow, _>(
-            stream,
-            &source_id.to_string(),
-            txns_ctx,
-            move || {
-                let (c, l) = (
-                    Arc::clone(&persist_clients),
-                    metadata.persist_location.clone(),
-                );
-                async move { c.open(l).await.expect("location is valid") }
-            },
-            txns_shard,
-            metadata.data_shard,
-            as_of
-                .expect("as_of is provided for table sources")
-                .into_option()
-                .expect("shard is not closed"),
-            until,
-            Arc::new(metadata.relation_desc),
-            Arc::new(UnitSchema),
-        ),
-        None => (stream, vec![]),
+    // upper. Render dataflow operators that pass through the inputs and
+    // translate the progress frontiers as necessary.
+    let (ok_stream, err_stream) = match metadata.txns_shard {
+        Some(txns_shard) => {
+            let (progress, remap_token) = TxnsProgress::new::<SourceData, (), i64, TxnsCodecRow, _>(
+                outer,
+                &name,
+                txns_ctx,
+                move || {
+                    let (c, l) = (
+                        Arc::clone(&persist_clients),
+                        metadata.persist_location.clone(),
+                    );
+                    async move { c.open(l).await.expect("location is valid") }
+                },
+                txns_shard,
+                metadata.data_shard,
+                as_of
+                    .expect("as_of is provided for table sources")
+                    .into_option()
+                    .expect("shard is not closed"),
+                Arc::new(metadata.relation_desc),
+                Arc::new(UnitSchema),
+            );
+            let (ok_stream, ok_token) = progress.translate(ok_stream, until.clone());
+            let (err_stream, err_token) = progress.translate(err_stream, until);
+            tokens.extend([remap_token, ok_token, err_token]);
+            (ok_stream, err_stream)
+        }
+        None => (ok_stream, err_stream),
     };
-    tokens.extend(txns_tokens);
-    let (ok_stream, err_stream) = stream.ok_err(|(d, t, r)| match d {
-        Ok(row) => Ok((row, t.0, r)),
-        Err(err) => Err((err, t.0, r)),
-    });
+
     (ok_stream, err_stream, tokens)
 }
 
@@ -299,7 +323,6 @@ type RefinedScope<'scope, T> = Scope<'scope, (T, Subtime)>;
 /// All times emitted will have been [advanced by] the given `as_of` frontier.
 ///
 /// [advanced by]: differential_dataflow::lattice::Lattice::advance_by
-#[allow(clippy::needless_borrow)]
 pub fn persist_source_core<'g, 'outer, E>(
     outer: Scope<'outer, mz_repr::Timestamp>,
     scope: RefinedScope<'g, mz_repr::Timestamp>,
@@ -311,25 +334,81 @@ pub fn persist_source_core<'g, 'outer, E>(
     snapshot_mode: SnapshotMode,
     until: Antichain<Timestamp>,
     map_filter_project: Option<&mut MfpPlan>,
-    flow_control: Option<FlowControl<'g, (mz_repr::Timestamp, Subtime)>>,
+    flow_control: Option<FlowControl<'g, RefinedTime>>,
     // If Some, an override for the default listen sleep retry parameters.
     listen_sleep: Option<impl Fn() -> RetryParameters + Send + 'static>,
     start_signal: impl Future<Output = ()> + Send + 'static,
     error_handler: ErrorHandler,
 ) -> (
-    Stream<
-        'g,
-        (mz_repr::Timestamp, Subtime),
-        Vec<(Result<Row, E>, (mz_repr::Timestamp, Subtime), Diff)>,
-    >,
+    StreamVec<'g, RefinedTime, (Result<Row, E>, RefinedTime, Diff)>,
     Vec<PressOnDropButton>,
 )
 where
     E: timely::ExchangeData + Ord + Clone + Debug + From<DataflowError> + From<EvalError>,
 {
-    let cfg = persist_clients.cfg().clone();
     let name = source_id.to_string();
     let filter_plan = map_filter_project.as_ref().map(|p| (*p).clone());
+    let (cfg, fetched, token) = fetch_parts(
+        outer,
+        scope,
+        source_id,
+        persist_clients,
+        metadata,
+        read_schema,
+        as_of,
+        snapshot_mode,
+        until.clone(),
+        filter_plan,
+        flow_control,
+        listen_sleep,
+        start_signal,
+        error_handler,
+    );
+    let (oks, errs) = decode_and_mfp::<E, RefinedTime, RowVecBuilder<RefinedTime>>(
+        cfg,
+        fetched,
+        &name,
+        until,
+        map_filter_project,
+        |time| time,
+    );
+    // `upsert` reads one collection of `Result`s. Records keep the refined time, so putting
+    // the sides back together is a move per record with no re-timestamping.
+    let rows = oks
+        .as_collection()
+        .map(Ok)
+        .concat(errs.as_collection().map(Err))
+        .inner;
+    (rows, token)
+}
+
+/// Fetch the parts of a persist shard a dataflow needs, distributing the work of reading them
+/// across all timely workers.
+#[allow(clippy::needless_borrow)]
+fn fetch_parts<'g, 'outer>(
+    outer: Scope<'outer, mz_repr::Timestamp>,
+    scope: RefinedScope<'g, mz_repr::Timestamp>,
+    source_id: GlobalId,
+    persist_clients: Arc<PersistClientCache>,
+    metadata: CollectionMetadata,
+    read_schema: Option<RelationDesc>,
+    as_of: Option<Antichain<Timestamp>>,
+    snapshot_mode: SnapshotMode,
+    until: Antichain<Timestamp>,
+    // The MFP whose filter is pushed down into persist, if any.
+    filter_plan: Option<MfpPlan>,
+    flow_control: Option<FlowControl<'g, RefinedTime>>,
+    // If Some, an override for the default listen sleep retry parameters.
+    listen_sleep: Option<impl Fn() -> RetryParameters + Send + 'static>,
+    start_signal: impl Future<Output = ()> + Send + 'static,
+    error_handler: ErrorHandler,
+) -> (
+    PersistConfig,
+    StreamVec<'g, RefinedTime, FetchedBlob<SourceData, (), Timestamp, StorageDiff>>,
+    Vec<PressOnDropButton>,
+) {
+    let cfg = persist_clients.cfg().clone();
+    let name = source_id.to_string();
 
     // N.B. `read_schema` may be a subset of the total columns for this shard.
     let read_desc = match read_schema {
@@ -403,8 +482,7 @@ where
         start_signal,
         error_handler,
     );
-    let rows = decode_and_mfp(cfg, fetched, &name, until, map_filter_project);
-    (rows, token)
+    (cfg, fetched, token)
 }
 
 fn filter_result(
@@ -453,23 +531,39 @@ fn filter_result(
     }
 }
 
-pub fn decode_and_mfp<'scope, E>(
+/// The time a decode operator's capabilities carry, refined with a [`Subtime`] so flow
+/// control can pace parts within a millisecond.
+type RefinedTime = (mz_repr::Timestamp, Subtime);
+
+/// Ok-side container builder producing row vectors timestamped with `T`.
+pub type RowVecBuilder<T> = ConsolidatingContainerBuilder<Vec<(Row, T, Diff)>>;
+
+/// Err-side container builder.
+type ErrBuilder<E, RT> = ConsolidatingContainerBuilder<Vec<(E, RT, Diff)>>;
+
+/// Decode fetched parts and apply `map_filter_project`, writing ok records into `CB`'s
+/// containers and err records into a separate output.
+///
+/// `record_time` picks what a record stores for its time. A reader that does not distinguish
+/// times within a millisecond passes `|time| time.0`, which drops the [`Subtime`] coordinate
+/// the enclosing scope refines with: that coordinate exists to pace flow control and stays on
+/// the capabilities, and keeping it in the records would force a re-encode to strip it later.
+/// A reader that builds a collection in the refined scope needs it, and passes `|time| time`.
+fn decode_and_mfp<'scope, E, RT, CB>(
     cfg: PersistConfig,
-    fetched: StreamVec<
-        'scope,
-        (mz_repr::Timestamp, Subtime),
-        FetchedBlob<SourceData, (), Timestamp, StorageDiff>,
-    >,
+    fetched: StreamVec<'scope, RefinedTime, FetchedBlob<SourceData, (), Timestamp, StorageDiff>>,
     name: &str,
     until: Antichain<Timestamp>,
     mut map_filter_project: Option<&mut MfpPlan>,
-) -> StreamVec<
-    'scope,
-    (mz_repr::Timestamp, Subtime),
-    (Result<Row, E>, (mz_repr::Timestamp, Subtime), Diff),
->
+    record_time: fn(RefinedTime) -> RT,
+) -> (
+    Stream<'scope, RefinedTime, CB::Container>,
+    StreamVec<'scope, RefinedTime, (E, RT, Diff)>,
+)
 where
     E: timely::ExchangeData + Ord + Clone + Debug + From<DataflowError> + From<EvalError>,
+    RT: Ord + Clone + Debug + 'static,
+    CB: ContainerBuilder + PushInto<(Row, RT, Diff)>,
 {
     let scope = fetched.scope();
     let mut builder = OperatorBuilder::new(
@@ -479,57 +573,68 @@ where
     let operator_info = builder.operator_info();
 
     let mut fetched_input = builder.new_input(fetched, Pipeline);
-    let (updates_output, updates_stream) = builder.new_output();
-    let mut updates_output = OutputBuilder::from(updates_output);
+    let (ok_output, ok_stream) = builder.new_output::<CB::Container>();
+    let mut ok_output: OutputBuilder<_, CB> = OutputBuilder::from(ok_output);
+    let (err_output, err_stream) = builder.new_output();
+    let mut err_output: OutputBuilder<_, ErrBuilder<E, RT>> = OutputBuilder::from(err_output);
 
-    // Re-used state for processing and building rows.
-    let mut datum_vec = mz_repr::DatumVec::new();
-    let mut row_builder = Row::default();
-
+    let name = name.to_owned();
     // Extract the MFP if it exists; leave behind an identity MFP in that case.
     let map_filter_project = map_filter_project.as_mut().map(|mfp| mfp.take());
 
     builder.build(move |_caps| {
-        let name = name.to_owned();
         // Acquire an activator to reschedule the operator when it has unfinished work.
-        let activations = scope.activations();
-        let activator = Activator::new(operator_info.address, activations);
-        // Maintain a list of work to do
-        let mut pending_work = std::collections::VecDeque::new();
+        let activator = Activator::new(operator_info.address, scope.activations());
         let panic_on_audit_failure = STATS_AUDIT_PANIC.handle(&cfg);
+        let mut pending_work = VecDeque::new();
+        let mut datum_vec = DatumVec::new();
+        let mut row_builder = Row::default();
 
         move |_frontier| {
             fetched_input.for_each(|time, data| {
-                let capability = time.retain(0);
-                for fetched_blob in data.drain(..) {
+                let capabilities = [time.retain(0), time.retain(1)];
+                let panic_on_audit_failure = panic_on_audit_failure.get();
+                for blob in data.drain(..) {
                     pending_work.push_back(PendingWork {
-                        panic_on_audit_failure: panic_on_audit_failure.get(),
-                        capability: capability.clone(),
-                        part: PendingPart::Unparsed(fetched_blob),
-                    })
+                        panic_on_audit_failure,
+                        capabilities: capabilities.clone(),
+                        part: PendingPart::Unparsed(blob),
+                    });
                 }
             });
 
-            // Get dyncfg values once per schedule to amortize the cost of
-            // loading the atomics.
+            // Get dyncfg values once per schedule to amortize the cost of loading the atomics.
             let yield_fuel = cfg.storage_source_decode_fuel();
-            let yield_fn = |_, work| work >= yield_fuel;
-
             let mut work = 0;
-            let start_time = Instant::now();
-            let mut output = updates_output.activate();
-            while !pending_work.is_empty() && !yield_fn(start_time, work) {
-                let done = pending_work.front_mut().unwrap().do_work(
-                    &mut work,
+            let mut ok_output = ok_output.activate();
+            let mut err_output = err_output.activate();
+            while let Some(front) = pending_work.front_mut() {
+                if work >= yield_fuel {
+                    break;
+                }
+                let cap_time = *front.capabilities[0].time();
+                // A session per part: dropping it flushes the container builder, so a
+                // container never mixes records from parts held at different capabilities.
+                let mut ok_session = ok_output.session_with_builder(&front.capabilities[0]);
+                let mut err_session = err_output.session_with_builder(&front.capabilities[1]);
+                let done = decode_part(
+                    &mut front.part,
+                    front.panic_on_audit_failure,
+                    cap_time,
                     &name,
-                    start_time,
-                    yield_fn,
                     &until,
                     map_filter_project.as_ref(),
                     &mut datum_vec,
                     &mut row_builder,
-                    &mut output,
+                    &mut work,
+                    yield_fuel,
+                    |record, time, diff| match record {
+                        Ok(row) => ok_session.give((row.into_owned(), record_time(time), diff)),
+                        Err(err) => err_session.give((err, record_time(time), diff)),
+                    },
                 );
+                drop(ok_session);
+                drop(err_session);
                 if done {
                     pending_work.pop_front();
                 }
@@ -540,15 +645,15 @@ where
         }
     });
 
-    updates_stream
+    (ok_stream, err_stream)
 }
 
 /// Pending work to read from fetched parts
 struct PendingWork {
     /// Whether to panic if a part fails an audit, or to just pass along the audited data.
     panic_on_audit_failure: bool,
-    /// The time at which the work should happen.
-    capability: Capability<(mz_repr::Timestamp, Subtime)>,
+    /// The time at which the work should happen, one capability per operator output.
+    capabilities: [Capability<RefinedTime>; 2],
     /// Pending fetched part.
     part: PendingPart,
 }
@@ -579,167 +684,157 @@ impl PendingPart {
     }
 }
 
-impl PendingWork {
-    /// Perform work, reading from the fetched part, decoding, and sending outputs, while checking
-    /// `yield_fn` whether more fuel is available.
-    fn do_work<YFn, E>(
-        &mut self,
-        work: &mut usize,
-        name: &str,
-        start_time: Instant,
-        yield_fn: YFn,
-        until: &Antichain<Timestamp>,
-        map_filter_project: Option<&MfpPlan>,
-        datum_vec: &mut DatumVec,
-        row_builder: &mut Row,
-        output: &mut OutputBuilderSession<
-            '_,
-            (mz_repr::Timestamp, Subtime),
-            ConsolidatingContainerBuilder<
-                Vec<(Result<Row, E>, (mz_repr::Timestamp, Subtime), Diff)>,
-            >,
-        >,
-    ) -> bool
-    where
-        YFn: Fn(Instant, usize) -> bool,
-        E: timely::ExchangeData + Ord + Clone + Debug + From<DataflowError> + From<EvalError>,
+/// Read `part`, apply the MFP, and hand every record to `give`, stopping once `work` reaches
+/// `yield_fuel`. Returns whether the part is exhausted.
+///
+/// Records carry `cap_time` with its millisecond replaced by the record's own time, so the
+/// caller must emit them at the capability `cap_time` came from.
+fn decode_part<E, F>(
+    part: &mut PendingPart,
+    panic_on_audit_failure: bool,
+    cap_time: RefinedTime,
+    name: &str,
+    until: &Antichain<Timestamp>,
+    map_filter_project: Option<&MfpPlan>,
+    datum_vec: &mut DatumVec,
+    row_builder: &mut Row,
+    work: &mut usize,
+    yield_fuel: usize,
+    mut give: F,
+) -> bool
+where
+    E: timely::ExchangeData + Ord + Clone + Debug + From<DataflowError> + From<EvalError>,
+    F: FnMut(Result<Cow<'_, Row>, E>, RefinedTime, Diff),
+{
+    let fetched_part = part.part_mut();
+    let is_filter_pushdown_audit = fetched_part.is_filter_pushdown_audit();
+    let mut row_buf = None;
+    while let Some(((key, val), time, diff)) =
+        fetched_part.next_with_storage(&mut row_buf, &mut None)
     {
-        let mut session = output.session_with_builder(&self.capability);
-        let fetched_part = self.part.part_mut();
-        let is_filter_pushdown_audit = fetched_part.is_filter_pushdown_audit();
-        let mut row_buf = None;
-        while let Some(((key, val), time, diff)) =
-            fetched_part.next_with_storage(&mut row_buf, &mut None)
-        {
-            if until.less_equal(&time) {
-                continue;
-            }
-            match (key, val) {
-                (SourceData(Ok(row)), ()) => {
-                    if let Some(mfp) = map_filter_project {
-                        // We originally accounted work as the number of outputs, to give downstream
-                        // operators a chance to reduce down anything we've emitted. This mfp call
-                        // might have a restrictive filter, which would have been counted as no
-                        // work. However, in practice, we've been decode_and_mfp be a source of
-                        // interactivity loss during rehydration, so we now also count each mfp
-                        // evaluation against our fuel.
-                        *work += 1;
-                        let arena = mz_repr::RowArena::new();
-                        let mut datums_local = datum_vec.borrow_with(&row);
-                        for result in mfp.evaluate(
-                            &mut datums_local,
-                            &arena,
-                            time,
-                            diff.into(),
-                            |time| !until.less_equal(time),
-                            row_builder,
-                        ) {
-                            // Earlier we decided this Part doesn't need to be fetched, but to
-                            // audit our logic we fetched it any way. If the MFP returned data it
-                            // means our earlier decision to not fetch this part was incorrect.
-                            if let Some(stats) = &is_filter_pushdown_audit {
-                                // NB: The tag added by this scope is used for alerting. The panic
-                                // message may be changed arbitrarily, but the tag key and val must
-                                // stay the same.
-                                sentry::with_scope(
-                                    |scope| {
-                                        scope
-                                            .set_tag("alert_id", "persist_pushdown_audit_violation")
-                                    },
-                                    || {
-                                        error!(
-                                            ?stats,
-                                            name,
-                                            mfp = ?redact(&mfp),
-                                            result = ?redact(&result),
-                                            "persist filter pushdown correctness violation!"
+        if until.less_equal(&time) {
+            continue;
+        }
+        match (key, val) {
+            (SourceData(Ok(row)), ()) => {
+                if let Some(mfp) = map_filter_project {
+                    // We originally accounted work as the number of outputs, to give downstream
+                    // operators a chance to reduce down anything we've emitted. This mfp call
+                    // might have a restrictive filter, which would have been counted as no
+                    // work. However, in practice, we've been decode_and_mfp be a source of
+                    // interactivity loss during rehydration, so we now also count each mfp
+                    // evaluation against our fuel.
+                    *work += 1;
+                    let arena = mz_repr::RowArena::new();
+                    let mut datums_local = datum_vec.borrow_with(&row);
+                    for result in mfp.evaluate(
+                        &mut datums_local,
+                        &arena,
+                        time,
+                        diff.into(),
+                        |time| !until.less_equal(time),
+                        row_builder,
+                    ) {
+                        // Earlier we decided this Part doesn't need to be fetched, but to
+                        // audit our logic we fetched it any way. If the MFP returned data it
+                        // means our earlier decision to not fetch this part was incorrect.
+                        if let Some(stats) = &is_filter_pushdown_audit {
+                            // NB: The tag added by this scope is used for alerting. The panic
+                            // message may be changed arbitrarily, but the tag key and val must
+                            // stay the same.
+                            sentry::with_scope(
+                                |scope| {
+                                    scope.set_tag("alert_id", "persist_pushdown_audit_violation")
+                                },
+                                || {
+                                    error!(
+                                        ?stats,
+                                        name,
+                                        mfp = ?redact(&mfp),
+                                        result = ?redact(&result),
+                                        "persist filter pushdown correctness violation!"
+                                    );
+                                    if panic_on_audit_failure {
+                                        panic!(
+                                            "persist filter pushdown correctness violation! {}",
+                                            name
                                         );
-                                        if self.panic_on_audit_failure {
-                                            panic!(
-                                                "persist filter pushdown correctness violation! {}",
-                                                name
-                                            );
-                                        }
-                                    },
-                                );
-                            }
-                            match result {
-                                Ok((row, time, diff)) => {
-                                    // Additional `until` filtering due to temporal filters.
-                                    if !until.less_equal(&time) {
-                                        let mut emit_time = *self.capability.time();
-                                        emit_time.0 = time;
-                                        session.give((Ok(row), emit_time, diff));
-                                        *work += 1;
                                     }
+                                },
+                            );
+                        }
+                        match result {
+                            Ok((row, time, diff)) => {
+                                // Additional `until` filtering due to temporal filters.
+                                if !until.less_equal(&time) {
+                                    let mut emit_time = cap_time;
+                                    emit_time.0 = time;
+                                    give(Ok(Cow::Owned(row)), emit_time, diff);
+                                    *work += 1;
                                 }
-                                Err((err, time, diff)) => {
-                                    // Additional `until` filtering due to temporal filters.
-                                    if !until.less_equal(&time) {
-                                        let mut emit_time = *self.capability.time();
-                                        emit_time.0 = time;
-                                        session.give((Err(err), emit_time, diff));
-                                        *work += 1;
-                                    }
+                            }
+                            Err((err, time, diff)) => {
+                                // Additional `until` filtering due to temporal filters.
+                                if !until.less_equal(&time) {
+                                    let mut emit_time = cap_time;
+                                    emit_time.0 = time;
+                                    give(Err(err), emit_time, diff);
+                                    *work += 1;
                                 }
                             }
                         }
-                        // At the moment, this is the only case where we can re-use the allocs for
-                        // the `SourceData`/`Row` we decoded. This could be improved if this timely
-                        // operator used a different container than `Vec<Row>`.
-                        drop(datums_local);
-                        row_buf.replace(SourceData(Ok(row)));
-                    } else {
-                        let mut emit_time = *self.capability.time();
-                        emit_time.0 = time;
-                        // Clone row so we retain our row allocation.
-                        session.give((Ok(row.clone()), emit_time, diff.into()));
-                        row_buf.replace(SourceData(Ok(row)));
-                        *work += 1;
                     }
-                }
-                (SourceData(Err(err)), ()) => {
-                    // A discarded part that turns out to hold an error row is
-                    // as much a pushdown violation as one whose MFP yields
-                    // output: errors must surface regardless of any filter.
-                    // Without this arm the audit was blind to exactly the
-                    // undercounted-err-stats violation class.
-                    if let Some(stats) = &is_filter_pushdown_audit {
-                        sentry::with_scope(
-                            |scope| scope.set_tag("alert_id", "persist_pushdown_audit_violation"),
-                            || {
-                                // `err` is redacted for the same reason the
-                                // `Ok`-row arm redacts its MFP output: these
-                                // events go to Sentry, and a `DecodeError`
-                                // carries the raw source record bytes while
-                                // several `EvalError`s embed user input.
-                                error!(
-                                    ?stats,
-                                    name,
-                                    err = ?redact(&err),
-                                    "persist filter pushdown correctness violation!"
-                                );
-                                if self.panic_on_audit_failure {
-                                    panic!(
-                                        "persist filter pushdown correctness violation! {}",
-                                        name
-                                    );
-                                }
-                            },
-                        );
-                    }
-                    let mut emit_time = *self.capability.time();
+                    // The MFP built its output into `row_builder`, so the decoded row's
+                    // allocation is free to go back to `row_buf`.
+                    drop(datums_local);
+                    row_buf.replace(SourceData(Ok(row)));
+                } else {
+                    let mut emit_time = cap_time;
                     emit_time.0 = time;
-                    session.give((Err(E::from(err)), emit_time, diff.into()));
+                    // The output copies the row out, so the allocation stays with `row_buf`.
+                    give(Ok(Cow::Borrowed(&row)), emit_time, diff.into());
+                    row_buf.replace(SourceData(Ok(row)));
                     *work += 1;
                 }
             }
-            if yield_fn(start_time, *work) {
-                return false;
+            (SourceData(Err(err)), ()) => {
+                // A discarded part that turns out to hold an error row is
+                // as much a pushdown violation as one whose MFP yields
+                // output: errors must surface regardless of any filter.
+                // Without this arm the audit was blind to exactly the
+                // undercounted-err-stats violation class.
+                if let Some(stats) = &is_filter_pushdown_audit {
+                    sentry::with_scope(
+                        |scope| scope.set_tag("alert_id", "persist_pushdown_audit_violation"),
+                        || {
+                            // `err` is redacted for the same reason the
+                            // `Ok`-row arm redacts its MFP output: these
+                            // events go to Sentry, and a `DecodeError`
+                            // carries the raw source record bytes while
+                            // several `EvalError`s embed user input.
+                            error!(
+                                ?stats,
+                                name,
+                                err = ?redact(&err),
+                                "persist filter pushdown correctness violation!"
+                            );
+                            if panic_on_audit_failure {
+                                panic!("persist filter pushdown correctness violation! {}", name);
+                            }
+                        },
+                    );
+                }
+                let mut emit_time = cap_time;
+                emit_time.0 = time;
+                give(Err(E::from(err)), emit_time, diff.into());
+                *work += 1;
             }
         }
-        true
+        if *work >= yield_fuel {
+            return false;
+        }
     }
+    true
 }
 
 /// A trait representing a type that can be used in `backpressure`.

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -73,21 +73,22 @@ pub(crate) fn render_sink<'scope>(
         let mut tokens = vec![];
         let sink_render = get_sink_render_for(&sink.connection);
 
-        let (ok_collection, err_collection, persist_tokens) = persist_source::persist_source(
-            scope,
-            sink.from,
-            Arc::clone(&storage_state.persist_clients),
-            &storage_state.txns_ctx,
-            sink.from_storage_metadata.clone(),
-            None,
-            Some(sink.as_of.clone()),
-            snapshot_mode,
-            timely::progress::Antichain::new(),
-            None,
-            None,
-            async {},
-            error_handler,
-        );
+        let (ok_collection, err_collection, persist_tokens) =
+            persist_source::persist_source::<_, persist_source::RowVecBuilder<Timestamp>>(
+                scope,
+                sink.from,
+                Arc::clone(&storage_state.persist_clients),
+                &storage_state.txns_ctx,
+                sink.from_storage_metadata.clone(),
+                None,
+                Some(sink.as_of.clone()),
+                snapshot_mode,
+                timely::progress::Antichain::new(),
+                None,
+                None,
+                async {},
+                error_handler,
+            );
         tokens.extend(persist_tokens);
 
         let batches = arrange_sink_input(&*sink_render, ok_collection.as_collection());

--- a/src/timely-util/src/columnar.rs
+++ b/src/timely-util/src/columnar.rs
@@ -34,11 +34,14 @@ use columnar::common::IterOwn;
 use columnar::{Clear, FromBytes, Index, Len};
 use columnar::{Columnar, Ref};
 use differential_dataflow::Hashable;
+use differential_dataflow::collection::containers::Enter;
 use differential_dataflow::trace::implementations::merge_batcher::MergeBatcher;
 use timely::Accountable;
 use timely::bytes::arc::Bytes;
 use timely::container::{DrainContainer, PushInto, SizableContainer};
 use timely::dataflow::channels::ContainerBytes;
+use timely::progress::Timestamp;
+use timely::progress::timestamp::Refines;
 
 use crate::columnation::ColInternalMerger;
 
@@ -188,6 +191,53 @@ where
                 // We really oughtn't be calling this in this case.
                 // We could convert to owned, but need more constraints on `C`.
                 unimplemented!("Pushing into Column::Bytes without first clearing");
+            }
+        }
+    }
+}
+
+/// Re-encodes a column's times into a refining timestamp, so a columnar collection can enter
+/// an iterative scope.
+impl<D, T1, T2, R> Enter<T1, T2> for Column<(D, T1, R)>
+where
+    D: Columnar,
+    T1: Columnar + Timestamp,
+    T2: Columnar + Refines<T1>,
+    R: Columnar,
+    (D, T1, R): Columnar<Container = (D::Container, T1::Container, R::Container)>,
+    (D, T2, R): Columnar<Container = (D::Container, T2::Container, R::Container)>,
+    for<'a> D::Container: columnar::Push<Ref<'a, D>>,
+    for<'a> T2::Container: columnar::Push<&'a T2>,
+    for<'a> R::Container: columnar::Push<Ref<'a, R>>,
+{
+    type InnerContainer = Column<(D, T2, R)>;
+
+    fn enter(self) -> Self::InnerContainer {
+        use columnar::Push;
+        match self {
+            // Only the times change, so the data and diff columns move across whole.
+            Column::Typed((data, times, diffs)) => {
+                let mut inner = T2::Container::default();
+                for time in times.borrow().into_index_iter() {
+                    inner.push(&T2::to_inner(T1::into_owned(time)));
+                }
+                Column::Typed((data, inner, diffs))
+            }
+            // A serialized column owns no typed sub-containers, so only the times are
+            // materialized. The data and diff columns go from their borrowed views
+            // straight into the output allocation, a copy per column rather than a
+            // decode and re-encode per record.
+            serialized => {
+                let (borrowed_data, borrowed_times, borrowed_diffs) = serialized.borrow();
+                let mut times = T2::Container::default();
+                for time in borrowed_times.into_index_iter() {
+                    times.push(&T2::to_inner(T1::into_owned(time)));
+                }
+                let view = (borrowed_data, times.borrow(), borrowed_diffs);
+                let words = indexed::length_in_words(&view);
+                let mut alloc: Vec<u64> = Vec::with_capacity(words);
+                indexed::encode(&mut alloc, &view);
+                Column::Align(alloc)
             }
         }
     }

--- a/src/txn-wal/src/operator.rs
+++ b/src/txn-wal/src/operator.rs
@@ -40,11 +40,11 @@ use timely::dataflow::operators::generic::OutputBuilder;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder as OperatorBuilderRc;
 use timely::dataflow::operators::vec::{Broadcast, Map};
 use timely::dataflow::operators::{Capture, Leave, Probe};
-use timely::dataflow::{ProbeHandle, Scope, StreamVec};
+use timely::dataflow::{ProbeHandle, Scope, Stream, StreamVec};
 use timely::order::TotalOrder;
 use timely::progress::{Antichain, Timestamp};
 use timely::worker::Worker;
-use timely::{PartialOrder, WorkerConfig};
+use timely::{Container, PartialOrder, WorkerConfig};
 use tracing::debug;
 
 use crate::TxnsCodecDefault;
@@ -114,31 +114,83 @@ where
     C: TxnsCodec + 'static,
     F: Future<Output = PersistClient> + Send + 'static,
 {
-    let unique_id = (name, passthrough.scope().addr()).hashed();
-    let (remap, source_button) = txns_progress_source_global::<K, V, T, D, P, C>(
+    let (progress, source_button) = TxnsProgress::new::<K, V, D, C, F>(
         passthrough.scope(),
         name,
-        ctx.clone(),
-        client_fn(),
+        ctx,
+        client_fn,
         txns_id,
         data_id,
         as_of,
         data_key_schema,
         data_val_schema,
-        unique_id,
     );
-    // Each of the `txns_frontiers` workers wants the full copy of the remap
-    // information.
-    let remap = remap.broadcast();
-    let (passthrough, frontiers_button) = txns_progress_frontiers::<K, V, T, D, P, C>(
-        remap,
-        passthrough,
-        name,
-        data_id,
-        until,
-        unique_id,
-    );
+    let (passthrough, frontiers_button) = progress.translate(passthrough, until);
     (passthrough, vec![source_button, frontiers_button])
+}
+
+/// A subscription to one data shard's remap information, from which any number of streams
+/// read off that shard can have their frontiers translated.
+///
+/// The subscription is the expensive half and does not depend on what is read, so it is
+/// rendered once by [`TxnsProgress::new`]. [`TxnsProgress::translate`] then renders one
+/// passthrough operator per stream, and is generic over the container so streams of
+/// different shapes can share a subscription.
+#[derive(Debug)]
+pub struct TxnsProgress<'scope, T: Timestamp> {
+    /// Broadcast remap stream, one operator per call to `translate` reads it.
+    remap: StreamVec<'scope, T, DataRemapEntry<T>>,
+    name: String,
+    data_id: ShardId,
+    /// Disambiguates the log lines of operators rendered for the same shard.
+    unique_id: u64,
+}
+
+impl<'scope, T> TxnsProgress<'scope, T>
+where
+    T: Timestamp + Lattice + TotalOrder + StepForward + Codec64 + Sync,
+{
+    /// Subscribe to `data_id`'s remap information and broadcast it to every worker.
+    pub fn new<K, V, D, C, F>(
+        scope: Scope<'scope, T>,
+        name: &str,
+        ctx: &TxnsContext,
+        client_fn: impl Fn() -> F,
+        txns_id: ShardId,
+        data_id: ShardId,
+        as_of: T,
+        data_key_schema: Arc<K::Schema>,
+        data_val_schema: Arc<V::Schema>,
+    ) -> (Self, PressOnDropButton)
+    where
+        K: Debug + Codec + Send + Sync,
+        V: Debug + Codec + Send + Sync,
+        D: Debug + Clone + 'static + Monoid + Ord + Codec64 + Send + Sync,
+        C: TxnsCodec + 'static,
+        F: Future<Output = PersistClient> + Send + 'static,
+    {
+        let unique_id = (name, scope.addr()).hashed();
+        let (remap, source_button) = txns_progress_source_global::<K, V, T, D, C>(
+            scope,
+            name,
+            ctx.clone(),
+            client_fn(),
+            txns_id,
+            data_id,
+            as_of,
+            data_key_schema,
+            data_val_schema,
+            unique_id,
+        );
+        // Each of the `txns_frontiers` workers wants the full copy of the remap information.
+        let progress = TxnsProgress {
+            remap: remap.broadcast(),
+            name: name.to_owned(),
+            data_id,
+            unique_id,
+        };
+        (progress, source_button)
+    }
 }
 
 /// Event sent from the subscribe Tokio task to the sync `txns_progress_source`
@@ -165,7 +217,7 @@ enum SourceEvent<T> {
 ///
 /// [reclocking design doc]:
 ///     https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20210714_reclocking.md
-fn txns_progress_source_global<'scope, K, V, T, D, P, C>(
+fn txns_progress_source_global<'scope, K, V, T, D, C>(
     scope: Scope<'scope, T>,
     name: &str,
     ctx: TxnsContext,
@@ -182,7 +234,6 @@ where
     V: Debug + Codec + Send + Sync,
     T: Timestamp + Lattice + TotalOrder + StepForward + Codec64 + Sync,
     D: Debug + Clone + 'static + Monoid + Ord + Codec64 + Send + Sync,
-    P: Debug + Clone + 'static,
     C: TxnsCodec + 'static,
 {
     let worker_idx = scope.index();
@@ -333,54 +384,55 @@ where
     (remap_stream, shutdown_button.press_on_drop())
 }
 
-/// The block ordering inside the schedule closure is load-bearing: pending
-/// passthrough input is emitted at the pre-activation capability BEFORE any
-/// capability downgrade, which keeps the differential invariant `send_time <=
-/// record_time` and avoids dropping in-flight rows when the passthrough
-/// frontier crosses `until` in the same activation (SQL-299). Do not reorder.
-fn txns_progress_frontiers<'scope, K, V, T, D, P, C>(
-    remap: StreamVec<'scope, T, DataRemapEntry<T>>,
-    passthrough: StreamVec<'scope, T, P>,
-    name: &str,
-    data_id: ShardId,
-    until: Antichain<T>,
-    unique_id: u64,
-) -> (StreamVec<'scope, T, P>, PressOnDropButton)
+impl<'scope, T> TxnsProgress<'scope, T>
 where
-    K: Debug + Codec,
-    V: Debug + Codec,
     T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
-    D: Clone + 'static + Monoid + Codec64 + Send + Sync,
-    P: Debug + Clone + 'static,
-    C: TxnsCodec,
 {
-    let scope = passthrough.scope();
-    let name = format!("txns_progress_frontiers({})", name);
-    let mut builder = OperatorBuilderRc::new(name.clone(), scope.clone());
-    let info = builder.operator_info();
-    let name = format!(
-        "{} [{}] {}/{} {:.9}",
-        name,
-        unique_id,
-        scope.index(),
-        scope.peers(),
-        data_id.to_string(),
-    );
-    let (passthrough_output, passthrough_stream) = builder.new_output::<Vec<P>>();
-    let mut passthrough_output = OutputBuilder::from(passthrough_output);
-    // Both inputs are disconnected from the output: capability advancement is
-    // driven manually based on the remap stream and the passthrough frontier.
-    // NB: the output is created BEFORE the inputs on purpose. `new_output`
-    // connects to whatever inputs already exist (here, none); the `[]`
-    // connection arg below records the input-to-output summary but does not by
-    // itself disconnect the output. Creating an input before the output would
-    // silently connect them and break the manual capability management.
-    let mut remap_input = builder.new_input_connection(remap, Pipeline, []);
-    let mut passthrough_input = builder.new_input_connection(passthrough, Pipeline, []);
+    /// Delay `passthrough`'s capability by the subscription's remap, translating the data
+    /// shard's physical frontier into the logical one.
+    ///
+    /// Call once per stream read off the shard. Streams of different container types can
+    /// share one subscription.
+    ///
+    /// The block ordering inside the schedule closure is load-bearing: pending
+    /// passthrough input is emitted at the pre-activation capability BEFORE any
+    /// capability downgrade, which keeps the differential invariant `send_time <=
+    /// record_time` and avoids dropping in-flight rows when the passthrough
+    /// frontier crosses `until` in the same activation (SQL-299). Do not reorder.
+    pub fn translate<C: Container>(
+        &self,
+        passthrough: Stream<'scope, T, C>,
+        until: Antichain<T>,
+    ) -> (Stream<'scope, T, C>, PressOnDropButton) {
+        let remap = self.remap.clone();
+        let (data_id, unique_id) = (self.data_id, self.unique_id);
+        let scope = passthrough.scope();
+        let name = format!("txns_progress_frontiers({})", self.name);
+        let mut builder = OperatorBuilderRc::new(name.clone(), scope.clone());
+        let info = builder.operator_info();
+        let name = format!(
+            "{} [{}] {}/{} {:.9}",
+            name,
+            unique_id,
+            scope.index(),
+            scope.peers(),
+            data_id.to_string(),
+        );
+        let (passthrough_output, passthrough_stream) = builder.new_output::<C>();
+        let mut passthrough_output = OutputBuilder::from(passthrough_output);
+        // Both inputs are disconnected from the output: capability advancement is
+        // driven manually based on the remap stream and the passthrough frontier.
+        // NB: the output is created BEFORE the inputs on purpose. `new_output`
+        // connects to whatever inputs already exist (here, none); the `[]`
+        // connection arg below records the input-to-output summary but does not by
+        // itself disconnect the output. Creating an input before the output would
+        // silently connect them and break the manual capability management.
+        let mut remap_input = builder.new_input_connection(remap, Pipeline, []);
+        let mut passthrough_input = builder.new_input_connection(passthrough, Pipeline, []);
 
-    let (mut shutdown_handle, shutdown_button) = button(scope, info.address);
+        let (mut shutdown_handle, shutdown_button) = button(scope, info.address);
 
-    builder.build_reschedule(move |capabilities| {
+        builder.build_reschedule(move |capabilities| {
         // The output capability's time tracks how far we've progressed in
         // copying along the passthrough input. `None` indicates that we've
         // dropped the capability to shut down.
@@ -474,7 +526,7 @@ where
             if let Some(cap) = capability.as_ref() {
                 let mut output = passthrough_output.activate();
                 passthrough_input.for_each(|_input_cap, data| {
-                    debug!("{} emitting data {:?}", name, data);
+                    debug!("{} emitting {} records", name, data.record_count());
                     output.session(cap).give_container(data);
                 });
             } else {
@@ -550,7 +602,8 @@ where
         }
     });
 
-    (passthrough_stream, shutdown_button.press_on_drop())
+        (passthrough_stream, shutdown_button.press_on_drop())
+    }
 }
 
 /// The process global [`TxnsRead`] that any operator can communicate with.
@@ -1328,14 +1381,13 @@ mod tests {
         pass: StreamVec<'a, u64, i64>,
         until: Antichain<u64>,
     ) -> (StreamVec<'a, u64, i64>, PressOnDropButton) {
-        txns_progress_frontiers::<String, (), u64, i64, i64, TxnsCodecDefault>(
+        let progress = TxnsProgress {
             remap,
-            pass,
-            "test",
-            ShardId::new(),
-            until,
-            0,
-        )
+            name: "test".into(),
+            data_id: ShardId::new(),
+            unique_id: 0,
+        };
+        progress.translate(pass, until)
     }
 
     /// Generates a random schedule for the no-data-loss fuzz test. Interleaves

--- a/test/sqllogictest/introspection/relations.slt
+++ b/test/sqllogictest/introspection/relations.slt
@@ -60,26 +60,27 @@ Feedback  persist_source_backpressure(backpressure(u1))  alloc::vec::Vec<core::c
 FlatMap  ArrangeBy[[Column(0,␠"a"),␠Column(1,␠"b")]]-errors  alloc::vec::Vec<((mz_compute::render::errors::DataflowErrorSer,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 FlatMap  Exchange  alloc::vec::Vec<(u64,␠mz_txn_wal::txn_read::DataRemapEntry<mz_repr::timestamp::Timestamp>)>
 FlatMap  txns_progress_frontiers(u1)  alloc::vec::Vec<mz_txn_wal::txn_read::DataRemapEntry<mz_repr::timestamp::Timestamp>>
+FlatMap  txns_progress_frontiers(u1)  alloc::vec::Vec<mz_txn_wal::txn_read::DataRemapEntry<mz_repr::timestamp::Timestamp>>
 FormArrangementKey  ArrangeBy[[Column(0,␠"a"),␠Column(1,␠"b")]]  mz_timely_util::columnar::Column<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 FormArrangementKey  Concatenate  alloc::vec::Vec<(mz_compute::render::errors::DataflowErrorSer,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 InputRegion:␠materialize.public.test_primary_idx  BuildRegion:␠materialize.public.test_primary_idx  alloc::vec::Vec<(mz_compute::render::errors::DataflowErrorSer,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
-InputRegion:␠materialize.public.test_primary_idx  BuildRegion:␠materialize.public.test_primary_idx  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
-LimitProgress(Dataflow:␠materialize.public.test_primary_idx)  Probe  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+InputRegion:␠materialize.public.test_primary_idx  BuildRegion:␠materialize.public.test_primary_idx  mz_timely_util::columnar::Column<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+LimitProgress(Dataflow:␠materialize.public.test_primary_idx)  Probe  mz_timely_util::columnar::Column<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 LogOperatorHydration␠(1)  FormArrangementKey  mz_timely_util::columnar::Column<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
-OkErr  SuppressEarlyProgress  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
-SuppressEarlyProgress  LimitProgress(Dataflow:␠materialize.public.test_primary_idx)  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
-VecToColumnar  BuildingObject(User(2))  mz_timely_util::columnar::Column<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+SuppressEarlyProgress  LimitProgress(Dataflow:␠materialize.public.test_primary_idx)  mz_timely_util::columnar::Column<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 decode_backpressure_probe(u1)  Feedback  alloc::vec::Vec<core::convert::Infallible>
 expire_stream_at(materialize.public.test_primary_idx_export_index_errs)  LogDataflowErrorsStream  alloc::vec::Vec<mz_row_spine::arc_batch::ArcBatch<differential_dataflow::trace::implementations::ord_neu::key_batch::OrdKeyBatch<mz_compute::typedefs::spines::MzStack<((mz_compute::render::errors::DataflowErrorSer,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
 expire_stream_at(materialize.public.test_primary_idx_export_index_oks)  InspectBatch  alloc::vec::Vec<mz_row_spine::arc_batch::ArcBatch<differential_dataflow::trace::implementations::ord_neu::val_batch::OrdValBatch<mz_row_spine::spines::RowRowLayout<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
 granular_backpressure(u1)  shard_source_descs_return(u1)  alloc::vec::Vec<core::convert::Infallible>
-granular_backpressure(u1)  txns_progress_frontiers(u1)  alloc::vec::Vec<(core::result::Result<mz_repr::row::Row,␠mz_compute::render::errors::DataflowErrorSer>,␠(mz_repr::timestamp::Timestamp,␠mz_storage_operators::persist_source::Subtime),␠mz_ore::overflowing::Overflowing<i64>)>
-persist_source::decode_and_mfp(u1)  InspectBatch  alloc::vec::Vec<(core::result::Result<mz_repr::row::Row,␠mz_compute::render::errors::DataflowErrorSer>,␠(mz_repr::timestamp::Timestamp,␠mz_storage_operators::persist_source::Subtime),␠mz_ore::overflowing::Overflowing<i64>)>
+granular_backpressure(u1)  txns_progress_frontiers(u1)  alloc::vec::Vec<(mz_compute::render::errors::DataflowErrorSer,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+granular_backpressure(u1)  txns_progress_frontiers(u1)  mz_timely_util::columnar::Column<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+persist_source::decode_and_mfp(u1)  InspectBatch  alloc::vec::Vec<(mz_compute::render::errors::DataflowErrorSer,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+persist_source::decode_and_mfp(u1)  InspectBatch  mz_timely_util::columnar::Column<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 persist_source_backpressure(backpressure(u1))  shard_source_fetch(u1)  alloc::vec::Vec<(usize,␠mz_persist_client::fetch::ExchangeableBatchPart<mz_repr::timestamp::Timestamp>)>
 shard_source_descs(u1)  granular_backpressure(u1)  alloc::vec::Vec<(usize,␠mz_persist_client::fetch::ExchangeableBatchPart<mz_repr::timestamp::Timestamp>)>
 shard_source_fetch(u1)  Feedback  alloc::vec::Vec<core::convert::Infallible>
 shard_source_fetch(u1)  persist_source::decode_and_mfp(u1)  alloc::vec::Vec<mz_persist_client::fetch::FetchedBlob<mz_storage_types::sources::SourceData,␠(),␠mz_repr::timestamp::Timestamp,␠i64>>
-txns_progress_frontiers(u1)  OkErr  alloc::vec::Vec<(core::result::Result<mz_repr::row::Row,␠mz_compute::render::errors::DataflowErrorSer>,␠(mz_repr::timestamp::Timestamp,␠mz_storage_operators::persist_source::Subtime),␠mz_ore::overflowing::Overflowing<i64>)>
+txns_progress_frontiers(u1)  SuppressEarlyProgress  mz_timely_util::columnar::Column<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 txns_progress_source(u1)  FlatMap  alloc::vec::Vec<mz_txn_wal::txn_read::DataRemapEntry<mz_repr::timestamp::Timestamp>>
 
 query IT rowsort
@@ -94,16 +95,14 @@ GROUP BY type;
 1  alloc::vec::Vec<((mz_compute::render::errors::DataflowErrorSer,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 1  alloc::vec::Vec<mz_persist_client::fetch::FetchedBlob<mz_storage_types::sources::SourceData,␠(),␠mz_repr::timestamp::Timestamp,␠i64>>
 1  mz_timely_util::columnar::Column<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+12  mz_timely_util::columnar::Column<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 2  alloc::vec::Vec<(u64,␠mz_txn_wal::txn_read::DataRemapEntry<mz_repr::timestamp::Timestamp>)>
 2  alloc::vec::Vec<(usize,␠mz_persist_client::fetch::ExchangeableBatchPart<mz_repr::timestamp::Timestamp>)>
-2  alloc::vec::Vec<mz_txn_wal::txn_read::DataRemapEntry<mz_repr::timestamp::Timestamp>>
-4  alloc::vec::Vec<(core::result::Result<mz_repr::row::Row,␠mz_compute::render::errors::DataflowErrorSer>,␠(mz_repr::timestamp::Timestamp,␠mz_storage_operators::persist_source::Subtime),␠mz_ore::overflowing::Overflowing<i64>)>
-4  mz_timely_util::columnar::Column<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+3  alloc::vec::Vec<mz_txn_wal::txn_read::DataRemapEntry<mz_repr::timestamp::Timestamp>>
 5  alloc::vec::Vec<core::convert::Infallible>
 5  alloc::vec::Vec<mz_row_spine::arc_batch::ArcBatch<differential_dataflow::trace::implementations::ord_neu::key_batch::OrdKeyBatch<mz_compute::typedefs::spines::MzStack<((mz_compute::render::errors::DataflowErrorSer,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
-6  alloc::vec::Vec<(mz_compute::render::errors::DataflowErrorSer,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
-6  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 6  alloc::vec::Vec<mz_row_spine::arc_batch::ArcBatch<differential_dataflow::trace::implementations::ord_neu::val_batch::OrdValBatch<mz_row_spine::spines::RowRowLayout<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
+9  alloc::vec::Vec<(mz_compute::render::errors::DataflowErrorSer,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 
 query TTT rowsort
 SELECT mdod_from.name AS from_name,


### PR DESCRIPTION
`decode_and_mfp` wrote both sides of a persist read into one container as `Result`s, so every
consumer of `persist_source` ran an `ok_err` demux, and a consumer that wanted columns paid a
second pass to re-encode the ok side. The decode operator gets a second output instead, with the
ok side generic over a container builder. The compute import asks for columns and gets them
straight from the decode; the storage sink and the materialized-view read-back ask for row
vectors and get the containers they had before, without the demux.

There is one decode implementation. `record_time` picks what a record stores for its time.
Compute passes `|time| time.0`, dropping the `Subtime` coordinate: it refines the capabilities so
flow control can pace parts within a millisecond, it stays on the capabilities either way, and no
reader of those streams distinguishes times that finely. `persist_source_core` passes
`|time| time` and keeps it, because `upsert` builds its collection inside the refined scope, then
joins the two sides back with `map` and `concat`. That is a move per record on a path that had
none, and it is the reason there is one decode operator rather than two.

Three commits, separable if you would rather review them apart:

* `txn-wal`: `txns_progress_remap` and `txns_progress_frontiers` are exposed separately, so the
  two streams share one subscription to the txns shard. `txns_progress_frontiers` becomes generic
  over the container it passes through.
* `timely-util`: an `Enter` impl for `Column<(D, T, R)>`, which a columnar collection needs to
  enter the iterative scope of a `WITH MUTUALLY RECURSIVE` dataflow.
* `storage-operators` and `compute`: the split itself.

On the table-import dataflow this removes the `OkErr` and `VecToColumnar` operators and four
`Vec<(Result<Row, E>, (Timestamp, Subtime), Diff)>` channels, visible in the change to
`test/sqllogictest/introspection/relations.slt`.

Not measured. The `map`/`concat` on the upsert rehydration read is the one place this adds work
rather than removing it, and `delay_sources_past_rehydration` exists because that path is
latency-sensitive, so it is worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
