### PR TITLE
release: bump to version v26.43.0-dev.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6584,7 +6584,7 @@ dependencies = [
 
 [[package]]
 name = "mz-balancerd"
-version = "26.41.0-dev.0"
+version = "26.43.0-dev.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6720,7 +6720,7 @@ dependencies = [
 
 [[package]]
 name = "mz-catalog-debug"
-version = "26.41.0-dev.0"
+version = "26.43.0-dev.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -6890,7 +6890,7 @@ dependencies = [
 
 [[package]]
 name = "mz-clusterd"
-version = "26.41.0-dev.0"
+version = "26.43.0-dev.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -7264,7 +7264,7 @@ dependencies = [
 
 [[package]]
 name = "mz-environmentd"
-version = "26.41.0-dev.0"
+version = "26.43.0-dev.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -7664,7 +7664,7 @@ dependencies = [
 
 [[package]]
 name = "mz-materialized"
-version = "26.41.0-dev.0"
+version = "26.43.0-dev.0"
 dependencies = [
  "custom-labels",
  "mz-clusterd",
@@ -7877,7 +7877,7 @@ dependencies = [
 
 [[package]]
 name = "mz-orchestratord"
-version = "26.41.0-dev.0"
+version = "26.43.0-dev.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8060,7 +8060,7 @@ dependencies = [
 
 [[package]]
 name = "mz-persist-client"
-version = "26.41.0-dev.0"
+version = "26.43.0-dev.0"
 dependencies = [
  "anyhow",
  "arrayvec 0.7.8",
@@ -9139,7 +9139,7 @@ dependencies = [
 
 [[package]]
 name = "mz-testdrive"
-version = "26.41.0-dev.0"
+version = "26.43.0-dev.0"
 dependencies = [
  "anyhow",
  "arrow 58.4.0",

--- a/doc/user/content/releases/v26.42.md
+++ b/doc/user/content/releases/v26.42.md
@@ -1,0 +1,10 @@
+---
+title: Materialize v26.42
+date: 2026-09-16
+released: false
+patch: 0
+rc: 1
+publish_helm_chart: true
+build:
+  render: never
+---

--- a/doc/user/content/releases/v26.43.md
+++ b/doc/user/content/releases/v26.43.md
@@ -1,0 +1,10 @@
+---
+title: Materialize v26.43
+date: 2026-09-23
+released: false
+patch: 0
+rc: 1
+publish_helm_chart: true
+build:
+  render: never
+---

--- a/doc/user/data/self_managed/materialize_operator_chart_parameter.yml
+++ b/doc/user/data/self_managed/materialize_operator_chart_parameter.yml
@@ -278,9 +278,9 @@
   type: string
   notationtype: ""
   autodefault: ""
-  default: '`nil`'
+  default: '`""`'
   autodescription: PriorityClass to use for environmentd pods spawned by the operator. The PriorityClass must already exist. Kubernetes rejects a pod that names one it cannot resolve, so a typo here stops these pods being created at all.
-  description: PriorityClass to use for environmentd pods spawned by the operator. The PriorityClass must already exist. Kubernetes rejects a pod that names one it cannot resolve, so a typo here stops these pods being created at all.
+  description: ""
   section: ""
   column: 3
   linenumber: 312
@@ -854,7 +854,7 @@
   type: string
   notationtype: ""
   autodefault: ""
-  default: '`"v26.39.0"`'
+  default: '`"v26.41.0"`'
   autodescription: The tag/version of the operator image to be used
   description: ""
   section: ""

--- a/misc/helm-charts/operator/Chart.yaml
+++ b/misc/helm-charts/operator/Chart.yaml
@@ -11,7 +11,7 @@ apiVersion: v2
 name: materialize-operator
 description: Materialize Kubernetes Operator Helm Chart
 type: application
-version: v26.41.0-dev.0
-appVersion: v26.41.0-dev.0
+version: v26.43.0-dev.0
+appVersion: v26.43.0-dev.0
 icon: https://materialize.com/favicon.ico
 home: https://materialize.com

--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -1,6 +1,6 @@
 # Materialize Kubernetes Operator Helm Chart
 
-![Version: v26.41.0-dev.0](https://img.shields.io/badge/Version-v26.41.0--dev.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.41.0-dev.0](https://img.shields.io/badge/AppVersion-v26.41.0--dev.0-informational?style=flat-square)
+![Version: v26.43.0-dev.0](https://img.shields.io/badge/Version-v26.43.0--dev.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.43.0-dev.0](https://img.shields.io/badge/AppVersion-v26.43.0--dev.0-informational?style=flat-square)
 
 Materialize Kubernetes Operator Helm Chart
 
@@ -178,7 +178,7 @@ The following table lists the configurable parameters of the Materialize operato
 | `operator.clusters.swap_enabled` | Configure sizes such that the pod QoS class is not Guaranteed, as is required for swap to be enabled. Disk doesn't make much sense with swap, as swap performs better than lgalloc, so it also gets disabled. | ``true`` |
 | `operator.image.pullPolicy` | Policy for pulling the image: "IfNotPresent" avoids unnecessary re-pulling of images | ``"IfNotPresent"`` |
 | `operator.image.repository` | The Docker repository for the operator image | ``"materialize/orchestratord"`` |
-| `operator.image.tag` | The tag/version of the operator image to be used | ``"v26.39.0"`` |
+| `operator.image.tag` | The tag/version of the operator image to be used | ``"v26.41.0"`` |
 | `operator.nodeSelector` | Node selector to use for the operator pod | ``{}`` |
 | `operator.podDisruptionBudget.enabled` | Whether to create a PodDisruptionBudget for the operator. Only created when `replicas` is greater than 1, since a budget over a single replica either blocks node drains or protects nothing. | ``true`` |
 | `operator.podDisruptionBudget.maxUnavailable` | Maximum number of operator pods that may be unavailable at once during voluntary disruptions. Expressed as a maximum rather than a minimum so that node drains are never blocked outright, they are only serialized. | ``1`` |
@@ -208,7 +208,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```shell
 helm install my-materialize-operator \
-  --set operator.image.tag=v26.41.0-dev.0 \
+  --set operator.image.tag=v26.43.0-dev.0 \
   materialize/materialize-operator
 ```
 
@@ -243,7 +243,7 @@ metadata:
   name: 12345678-1234-1234-1234-123456789012
   namespace: materialize-environment
 spec:
-  environmentdImageRef: materialize/environmentd:v26.41.0-dev.0
+  environmentdImageRef: materialize/environmentd:v26.43.0-dev.0
   backendSecretName: materialize-backend
   environmentdResourceRequirements:
     limits:

--- a/misc/helm-charts/operator/tests/deployment_test.yaml
+++ b/misc/helm-charts/operator/tests/deployment_test.yaml
@@ -17,7 +17,7 @@ tests:
       of: Deployment
   - equal:
       path: spec.template.spec.containers[0].image
-      value: materialize/orchestratord:v26.39.0
+      value: materialize/orchestratord:v26.41.0
   - equal:
       path: spec.template.spec.containers[0].imagePullPolicy
       value: IfNotPresent
@@ -71,7 +71,7 @@ tests:
 
 - it: should omit the statement logging sample rate when unset
   set:
-    operator.args.statementLoggingMaxSampleRate: null
+    operator.args.statementLoggingMaxSampleRate:
   asserts:
   - notContains:
       path: spec.template.spec.containers[0].args

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -13,7 +13,7 @@ operator:
     # -- The Docker repository for the operator image
     repository: materialize/orchestratord
     # -- The tag/version of the operator image to be used
-    tag: v26.39.0
+    tag: v26.41.0
     # -- Policy for pulling the image: "IfNotPresent" avoids unnecessary re-pulling of images
     pullPolicy: IfNotPresent
 

--- a/misc/helm-charts/testing/materialize.yaml
+++ b/misc/helm-charts/testing/materialize.yaml
@@ -29,7 +29,7 @@ metadata:
   name: 12345678-1234-1234-1234-123456789012
   namespace: materialize-environment
 spec:
-  environmentdImageRef: materialize/environmentd:v26.41.0-dev.0
+  environmentdImageRef: materialize/environmentd:v26.43.0-dev.0
   backendSecretName: materialize-backend
   authenticatorKind: None
   #balancerdExternalCertificateSpec:

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-balancerd"
 description = "Balancer service."
-version = "26.41.0-dev.0"
+version = "26.43.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/catalog-debug/Cargo.toml
+++ b/src/catalog-debug/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-catalog-debug"
 description = "Durable metadata storage debug tool."
-version = "26.41.0-dev.0"
+version = "26.43.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-clusterd"
 description = "Materialize's cluster server."
-version = "26.41.0-dev.0"
+version = "26.43.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-environmentd"
 description = "Manages a single Materialize environment."
-version = "26.41.0-dev.0"
+version = "26.43.0-dev.0"
 authors = ["Materialize, Inc."]
 license = "proprietary"
 edition.workspace = true

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-materialized"
 description = "Materialize's unified binary."
-version = "26.41.0-dev.0"
+version = "26.43.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/orchestratord/Cargo.toml
+++ b/src/orchestratord/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-orchestratord"
 description = "Kubernetes operator for Materialize regions"
-version = "26.41.0-dev.0"
+version = "26.43.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-persist-client"
 description = "Client for Materialize pTVC durability system"
-version = "26.41.0-dev.0"
+version = "26.43.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-testdrive"
 description = "Integration test driver for Materialize."
-version = "26.41.0-dev.0"
+version = "26.43.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false


### PR DESCRIPTION
Restores the commits that [`auto_cut_release.py`](https://github.com/MaterializeInc/materialize/blob/main/misc/python/materialize/release/auto_cut_release.py) produced but could not push when the v26.42 cut ran on 2026-09-11, plus the doc file dropped by the v26.41 cut on 2026-09-04. Same situation as #38567.

## What happened

[`Cut release` run 34553906086](https://github.com/MaterializeInc/release/actions/runs/34553906086) tagged and pushed `v26.42.0-rc.1` successfully, then failed on its last step:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - 2 of 2 required status checks are expected.
```

`auto_cut_release.py` pushes the post-tag bump straight to `main`, which branch protection now refuses. The run made both commits on the runner and lost them. The same thing happened on 2026-09-04 and on 2026-08-28; only the 08-28 one was restored (#38567).

## What this PR contains

- **`release: bump to version v26.43.0-dev.0`** - produced by running `bin/bump-version v26.43.0-dev.0`, not by hand. 15 files, +29/-29, matching the diffstat the failed run reported.
- **`release: create doc file for v26.42`** - dropped by the 2026-09-04 cut and never restored. `v26.42.md` is missing from `main` today even though v26.42 is the release currently being qualified.
- **`release: create doc file for v26.43`** - dropped by this week's cut.

## Two lines worth a second look

`bin/bump-version` regenerates `doc/user/data/self_managed/materialize_operator_chart_parameter.yml` and rewrites `misc/helm-charts/operator/tests/deployment_test.yaml` through ruamel, and both pick up changes that are not version bumps:

- The `priorityClass` `description` added by #38457 is emptied, because `value_descriptions.yml.gotmpl` does not emit a description for that field. If that text should survive regeneration it needs to come from the template.
- `statementLoggingMaxSampleRate: null` becomes `statementLoggingMaxSampleRate:`, a ruamel round-trip artifact. Semantically identical YAML.

These are kept rather than stripped so this PR is exactly what the workflow would have pushed; any future bump reproduces them. `check-helm-docs.sh` only covers `misc/helm-charts/operator`, and the regenerated `README.md` matches it.

## Follow-up

This will recur every Friday until https://linear.app/materializeinc/issue/SEC-725/replace-gh-token-for-the-release-automation-currently-a-personal-pat is implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzQZdcie5q75t4NJjUQDeB
