### PR TITLE
docs: clarify source snapshot statistics and stall recovery

### DIFF
--- a/doc/user/content/ingest-data/lifecycle-of-a-source.md
+++ b/doc/user/content/ingest-data/lifecycle-of-a-source.md
@@ -35,6 +35,9 @@ one upstream relation.
 | `stalled`  | The object hit an error. The `error` column reports the cause.                |
 | `dropped`  | The object was dropped. Terminal.                                             |
 
+`stalled` covers both errors that Materialize retries on its own and errors that
+do not clear until you act. See [Stalled](#stalled).
+
 The examples below use a PostgreSQL source and a Kafka source on a dedicated
 cluster. Substitute your own object names.
 
@@ -131,12 +134,45 @@ While the snapshot is in progress, `snapshot_records_staged` climbs toward
 `snapshot_records_known` and `snapshot_committed` is `f`. A table cannot serve
 queries until its snapshot completes: queries against it block until then.
 
+Nothing is committed until the whole snapshot has been read, because
+Materialize ingests it at a single timestamp. So `offset_committed` does not
+advance for the duration, and on upsert sources even `updates_staged` sits at
+`0`, because the source buffers the snapshot while it builds its in-memory
+index. In those statistics a snapshot that is progressing normally is
+indistinguishable from a stuck one, so read progress from
+`snapshot_records_staged`, `messages_received`, and `bytes_received`.
+
 {{< note >}}
 These statistics are collected periodically, so for a window after an object
 starts running they can read `NULL` and `f` even though the data is already
 ingested and queryable. They also reset when a replica restarts. Track how they
 evolve rather than reading them at a single moment.
 {{< /note >}}
+
+[`mz_hydration_statuses`](/sql/system-catalog/mz_internal/#mz_hydration_statuses)
+answers the same question one level up, per source and replica rather than per
+table:
+
+```mzsql
+SELECT o.name, h.hydrated
+FROM mz_internal.mz_hydration_statuses h
+JOIN mz_objects o ON o.id = h.object_id
+WHERE o.name IN ('pg_src', 'kafka_src')
+ORDER BY o.name;
+```
+
+```nofmt
+   name    | hydrated
+-----------+----------
+ kafka_src | t
+ pg_src    | t
+(2 rows)
+```
+
+`hydrated` is `false` while any table attached to the source is still
+snapshotting, whatever the source type, which makes it a cheap source-level
+check. It is not specific to the initial snapshot: a replica restart resets it
+too, after which it tracks the source rebuilding its in-memory state.
 
 Snapshot duration and upstream impact vary by source type. CDC sources
 (PostgreSQL, MySQL, SQL Server) require the upstream system to retain its
@@ -245,6 +281,27 @@ reported it, which tells you which part of the pipeline failed:
 ```nofmt
 {"namespaced":{"postgres":"publication \"mz_orders\" does not exist"}}
 ```
+
+### Which stalls clear on their own
+
+Errors unrelated to the ingested data, such as a connection failure, an
+authentication failure, or an upstream restart, are retried. Materialize
+restarts the ingestion dataflow when it needs to, and the object moves back
+through `starting` to `running` once the upstream problem clears. Repeated
+`stalled` and `starting` transitions in
+[`mz_source_status_history`](#reviewing-the-full-history) are the signature of
+an error being retried.
+
+Other errors are definite: the upstream system changed in a way that invalidates
+what Materialize has already ingested. Dropping the publication a PostgreSQL
+source replicates from, dropping or truncating an upstream table, invalidating a
+replication slot, and an incompatible upstream schema change all land here.
+Materialize records a definite error durably against the affected table, so
+reads of that table return it and restarting the dataflow does not clear it.
+Recovery means fixing the upstream cause and recreating the affected tables, as
+in [Absorbing upstream schema
+changes](/ingest-data/patterns/upstream-schema-changes/#recover-from-an-unplanned-change).
+The stall above is one of these, so `orders` cannot be repaired in place.
 
 For causes and fixes, see [Troubleshooting data
 ingestion](/ingest-data/troubleshooting/) for any source type, and the

--- a/doc/user/content/ingest-data/monitoring-data-ingestion.md
+++ b/doc/user/content/ingest-data/monitoring-data-ingestion.md
@@ -32,6 +32,10 @@ INNER JOIN mz_objects AS o ON (s.id = o.id)
 WHERE NOT s.snapshot_committed;
 ```
 
+Materialize commits the snapshot only once all of it has been read, so a
+source's committed statistics do not move while it snapshots. See [Understand
+the lifecycle of a source](/ingest-data/lifecycle-of-a-source/#snapshotting).
+
 It's also important to monitor CPU and memory utilization for the cluster
 hosting the source during snapshotting. If there are signs of resource
 exhaustion, you may need to [resize the cluster](/sql/alter-cluster/#alter-cluster-size).


### PR DESCRIPTION
### Motivation

Follow-up to @patrickwwbutler's review comments on https://github.com/MaterializeInc/materialize/pull/38758, which merged before they were addressed.

### Description

- **Retried vs. definite stalls**: the states table now says `stalled` covers both, and a new "Which stalls clear on their own" section explains that data-unrelated errors are retried, while definite ones (dropped publication, dropped or truncated upstream table, invalidated slot, incompatible schema change) are recorded durably against the affected table and need the table recreated.
- **Snapshot statistics**: a snapshot is ingested at a single timestamp, so nothing commits until all of it has been read. The committed statistics stay put for the duration (and on upsert sources `updates_staged` sits at `0` too), so progress has to be read from `snapshot_records_staged`, `messages_received`, or `bytes_received`. Cross-referenced from the snapshot-progress query in the monitoring guide.
- **`mz_hydration_statuses`**: documented as the source-level "is this source still snapshotting?" check, which does work for non-upsert sources, with the caveats that it reports per source and replica rather than per table and that a replica restart resets it.

Discussion of the one suggestion I did not take verbatim is in a comment on https://github.com/MaterializeInc/materialize/pull/38758.

### Verification

`hugo` builds both output formats cleanly and the new anchors resolve. Preview:

- https://preview.materialize.com/materialize/38786/ingest-data/lifecycle-of-a-source/
- https://preview.materialize.com/materialize/38786/ingest-data/monitoring-data-ingestion/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTLLpuyYS45T3jgbKnhMXo