### PR TITLE
envd: collect and record replica swap metrics

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -227,6 +227,7 @@ usage.
 | `disk_bytes`        | [`uint8`]    | Approximate disk usage, in bytes.
 | `heap_bytes`        | [`uint8`]    | Approximate heap (RAM + swap) usage, in bytes.
 | `heap_limit`        | [`uint8`]    | Available heap (RAM + swap) space, in bytes.
+| `swap_bytes`        | [`uint8`]    | Approximate swap usage, in bytes.
 
 ## `mz_cluster_replica_metrics_history`
 
@@ -252,6 +253,7 @@ history is retained across restarts.
 | `occurred_at`    | [`timestamp with time zone`] | Wall-clock timestamp at which the event occurred.
 | `heap_bytes`     | [`uint8`] | Approximate heap (RAM + swap) usage, in bytes.
 | `heap_limit`     | [`uint8`] | Available heap (RAM + swap) space, in bytes.
+| `swap_bytes`     | [`uint8`] | Approximate swap usage, in bytes.
 
 ## `mz_cluster_replica_statuses`
 
@@ -298,6 +300,7 @@ At this time, we do not make any guarantees about the exactness or freshness of 
 | `memory_percent` | [`double precision`] | Approximate RAM usage, in percent of the total allocation.
 | `disk_percent`   | [`double precision`] | Approximate disk usage, in percent of the total allocation.
 | `heap_percent`   | [`double precision`] | Approximate heap (RAM + swap) usage, in percent of the total allocation.
+| `swap_percent`   | [`double precision`] | Approximate swap usage, in percent of the total heap allocation.
 
 ## `mz_cluster_replica_utilization_history`
 
@@ -316,6 +319,7 @@ At this time, we do not make any guarantees about the exactness or freshness of 
 | `memory_percent` | [`double precision`] | Approximate RAM usage, in percent of the total allocation.
 | `disk_percent`   | [`double precision`] | Approximate disk usage, in percent of the total allocation.
 | `heap_percent`   | [`double precision`] | Approximate heap (RAM + swap) usage, in percent of the total allocation.
+| `swap_percent`   | [`double precision`] | Approximate swap usage, in percent of the total heap allocation.
 | `occurred_at`    | [`timestamp with time zone`] | Wall-clock timestamp at which the event occurred.
 
 ## `mz_cluster_replica_history`

--- a/src/adapter/src/catalog/open/builtin_schema_migration.rs
+++ b/src/adapter/src/catalog/open/builtin_schema_migration.rs
@@ -462,6 +462,16 @@ static MIGRATIONS: LazyLock<Vec<MigrationStep>> = LazyLock::new(|| {
             MZ_INTERNAL_SCHEMA,
             "mz_object_dependencies",
         ),
+        // Adding the `swap_bytes` column to `mz_cluster_replica_metrics_history`
+        // is a backward-compatible append, so the shard schema can evolve in
+        // place. See the NOTE above: this version must stay at the workspace's
+        // current dev version until the change ships.
+        MigrationStep::evolution(
+            "26.43.0-dev.0",
+            CatalogItemType::Source,
+            MZ_INTERNAL_SCHEMA,
+            "mz_cluster_replica_metrics_history",
+        ),
     ]
 });
 

--- a/src/catalog/src/builtin/mz_internal.rs
+++ b/src/catalog/src/builtin/mz_internal.rs
@@ -2734,6 +2734,7 @@ pub static MZ_CLUSTER_REPLICA_METRICS_HISTORY: LazyLock<BuiltinSource> =
                 "Approximate heap (RAM + swap) usage, in bytes.",
             ),
             ("heap_limit", "Available heap (RAM + swap) space, in bytes."),
+            ("swap_bytes", "Approximate swap usage, in bytes."),
         ]),
         is_retained_metrics_object: false,
         access: vec![PUBLIC_SELECT],
@@ -2752,6 +2753,7 @@ pub static MZ_CLUSTER_REPLICA_METRICS: LazyLock<BuiltinView> = LazyLock::new(|| 
         .with_column("disk_bytes", SqlScalarType::UInt64.nullable(true))
         .with_column("heap_bytes", SqlScalarType::UInt64.nullable(true))
         .with_column("heap_limit", SqlScalarType::UInt64.nullable(true))
+        .with_column("swap_bytes", SqlScalarType::UInt64.nullable(true))
         .with_key(vec![0, 1])
         .finish(),
     column_comments: BTreeMap::from_iter([
@@ -2768,6 +2770,7 @@ pub static MZ_CLUSTER_REPLICA_METRICS: LazyLock<BuiltinView> = LazyLock::new(|| 
             "Approximate heap (RAM + swap) usage, in bytes.",
         ),
         ("heap_limit", "Available heap (RAM + swap) space, in bytes."),
+        ("swap_bytes", "Approximate swap usage, in bytes."),
     ]),
     sql: "
 SELECT
@@ -2778,7 +2781,8 @@ SELECT
     memory_bytes,
     disk_bytes,
     heap_bytes,
-    heap_limit
+    heap_limit,
+    swap_bytes
 FROM mz_internal.mz_cluster_replica_metrics_history
 JOIN mz_cluster_replicas r ON r.id = replica_id
 ORDER BY replica_id, process_id, occurred_at DESC",
@@ -2805,6 +2809,7 @@ ORDER BY replica_id, process_id, occurred_at DESC",
                 ("disk_bytes", SemanticType::ByteCount),
                 ("heap_bytes", SemanticType::ByteCount),
                 ("heap_limit", SemanticType::ByteCount),
+                ("swap_bytes", SemanticType::ByteCount),
             ]
         },
     }),
@@ -5421,6 +5426,7 @@ pub static MZ_CLUSTER_REPLICA_UTILIZATION: LazyLock<BuiltinView> = LazyLock::new
         .with_column("memory_percent", SqlScalarType::Float64.nullable(true))
         .with_column("disk_percent", SqlScalarType::Float64.nullable(true))
         .with_column("heap_percent", SqlScalarType::Float64.nullable(true))
+        .with_column("swap_percent", SqlScalarType::Float64.nullable(true))
         .finish(),
     column_comments: BTreeMap::from_iter([
         ("replica_id", "The ID of a cluster replica."),
@@ -5441,6 +5447,10 @@ pub static MZ_CLUSTER_REPLICA_UTILIZATION: LazyLock<BuiltinView> = LazyLock::new
             "heap_percent",
             "Approximate heap (RAM + swap) usage, in percent of the total allocation.",
         ),
+        (
+            "swap_percent",
+            "Approximate swap usage, in percent of the total heap allocation.",
+        ),
     ]),
     sql: "
 SELECT
@@ -5449,7 +5459,8 @@ SELECT
     m.cpu_nano_cores::float8 / NULLIF(s.cpu_nano_cores, 0) * 100 AS cpu_percent,
     m.memory_bytes::float8 / NULLIF(s.memory_bytes, 0) * 100 AS memory_percent,
     m.disk_bytes::float8 / NULLIF(s.disk_bytes, 0) * 100 AS disk_percent,
-    m.heap_bytes::float8 / NULLIF(m.heap_limit, 0) * 100 AS heap_percent
+    m.heap_bytes::float8 / NULLIF(m.heap_limit, 0) * 100 AS heap_percent,
+    m.swap_bytes::float8 / NULLIF(m.heap_limit, 0) * 100 AS swap_percent
 FROM
     mz_catalog.mz_cluster_replicas AS r
         JOIN mz_catalog.mz_cluster_replica_sizes AS s ON r.size = s.size
@@ -5486,6 +5497,7 @@ pub static MZ_CLUSTER_REPLICA_UTILIZATION_HISTORY: LazyLock<BuiltinView> =
             .with_column("memory_percent", SqlScalarType::Float64.nullable(true))
             .with_column("disk_percent", SqlScalarType::Float64.nullable(true))
             .with_column("heap_percent", SqlScalarType::Float64.nullable(true))
+            .with_column("swap_percent", SqlScalarType::Float64.nullable(true))
             .with_column(
                 "occurred_at",
                 SqlScalarType::TimestampTz { precision: None }.nullable(false),
@@ -5511,6 +5523,10 @@ pub static MZ_CLUSTER_REPLICA_UTILIZATION_HISTORY: LazyLock<BuiltinView> =
                 "Approximate heap (RAM + swap) usage, in percent of the total allocation.",
             ),
             (
+                "swap_percent",
+                "Approximate swap usage, in percent of the total heap allocation.",
+            ),
+            (
                 "occurred_at",
                 "Wall-clock timestamp at which the event occurred.",
             ),
@@ -5523,6 +5539,7 @@ SELECT
     m.memory_bytes::float8 / NULLIF(s.memory_bytes, 0) * 100 AS memory_percent,
     m.disk_bytes::float8 / NULLIF(s.disk_bytes, 0) * 100 AS disk_percent,
     m.heap_bytes::float8 / NULLIF(m.heap_limit, 0) * 100 AS heap_percent,
+    m.swap_bytes::float8 / NULLIF(m.heap_limit, 0) * 100 AS swap_percent,
     m.occurred_at
 FROM
     mz_catalog.mz_cluster_replicas AS r

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -636,6 +636,7 @@ impl Controller {
                     Datum::TimestampTz(now_tz),
                     m.heap_bytes.into(),
                     m.heap_limit.into(),
+                    m.swap_bytes.into(),
                 ]);
                 (row.clone(), mz_repr::Diff::ONE)
             })

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -1592,6 +1592,7 @@ impl OrchestratorWorker {
                 };
 
                 process_metrics.heap_limit = usage.heap_limit;
+                process_metrics.swap_bytes = usage.swap_bytes;
             }
 
             process_metrics

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -559,6 +559,7 @@ impl OrchestratorWorker {
                 disk_bytes: None,
                 heap_bytes: None,
                 heap_limit: None,
+                swap_bytes: None,
             });
         }
         Ok(metrics)

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -154,6 +154,7 @@ pub struct ServiceProcessMetrics {
     pub disk_bytes: Option<u64>,
     pub heap_bytes: Option<u64>,
     pub heap_limit: Option<u64>,
+    pub swap_bytes: Option<u64>,
 }
 
 /// A simple language for describing assertions about a label's existence and value.

--- a/src/storage-client/src/healthcheck.rs
+++ b/src/storage-client/src/healthcheck.rs
@@ -174,6 +174,7 @@ pub static REPLICA_METRICS_HISTORY_DESC: LazyLock<RelationDesc> = LazyLock::new(
         )
         .with_column("heap_bytes", SqlScalarType::UInt64.nullable(true))
         .with_column("heap_limit", SqlScalarType::UInt64.nullable(true))
+        .with_column("swap_bytes", SqlScalarType::UInt64.nullable(true))
         .finish()
 });
 

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -149,6 +149,7 @@ memory_bytes  uint8  Approximate␠RAM␠usage,␠in␠bytes.
 disk_bytes  uint8  Approximate␠disk␠usage,␠in␠bytes.
 heap_bytes  uint8  Approximate␠heap␠(RAM␠+␠swap)␠usage,␠in␠bytes.
 heap_limit  uint8  Available␠heap␠(RAM␠+␠swap)␠space,␠in␠bytes.
+swap_bytes  uint8  Approximate␠swap␠usage,␠in␠bytes.
 
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_internal' AND object = 'mz_cluster_replica_metrics_history' ORDER BY position
@@ -161,6 +162,7 @@ disk_bytes  uint8  Approximate␠disk␠usage,␠in␠bytes.
 occurred_at  timestamp␠with␠time␠zone  Wall-clock␠timestamp␠at␠which␠the␠event␠occurred.
 heap_bytes  uint8  Approximate␠heap␠(RAM␠+␠swap)␠usage,␠in␠bytes.
 heap_limit  uint8  Available␠heap␠(RAM␠+␠swap)␠space,␠in␠bytes.
+swap_bytes  uint8  Approximate␠swap␠usage,␠in␠bytes.
 
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_internal' AND object = 'mz_cluster_replica_statuses' ORDER BY position
@@ -189,6 +191,7 @@ cpu_percent  double␠precision  Approximate␠CPU␠usage,␠in␠percent␠of�
 memory_percent  double␠precision  Approximate␠RAM␠usage,␠in␠percent␠of␠the␠total␠allocation.
 disk_percent  double␠precision  Approximate␠disk␠usage,␠in␠percent␠of␠the␠total␠allocation.
 heap_percent  double␠precision  Approximate␠heap␠(RAM␠+␠swap)␠usage,␠in␠percent␠of␠the␠total␠allocation.
+swap_percent  double␠precision  Approximate␠swap␠usage,␠in␠percent␠of␠the␠total␠heap␠allocation.
 
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_internal' AND object = 'mz_cluster_replica_utilization_history' ORDER BY position
@@ -199,6 +202,7 @@ cpu_percent  double␠precision  Approximate␠CPU␠usage,␠in␠percent␠of�
 memory_percent  double␠precision  Approximate␠RAM␠usage,␠in␠percent␠of␠the␠total␠allocation.
 disk_percent  double␠precision  Approximate␠disk␠usage,␠in␠percent␠of␠the␠total␠allocation.
 heap_percent  double␠precision  Approximate␠heap␠(RAM␠+␠swap)␠usage,␠in␠percent␠of␠the␠total␠allocation.
+swap_percent  double␠precision  Approximate␠swap␠usage,␠in␠percent␠of␠the␠total␠heap␠allocation.
 occurred_at  timestamp␠with␠time␠zone  Wall-clock␠timestamp␠at␠which␠the␠event␠occurred.
 
 query TTT

--- a/test/sqllogictest/catalog_server_explain.slt
+++ b/test/sqllogictest/catalog_server_explain.slt
@@ -709,7 +709,7 @@ mz_internal.mz_cluster_replica_metrics_ind:
 
 mz_internal.mz_cluster_replica_metrics:
   →Map/Filter/Project
-    Project: #0..=#4, #6, #7
+    Project: #0..=#4, #6..=#8
       →Non-monotonic TopK
         Group By #0, #1
         Order By #5 desc nulls_first
@@ -8451,8 +8451,8 @@ Explained Query:
   →One-Shot Delta Join [%0:mz_cluster_replicas » %1:mz_cluster_replica_sizes[#0{size}] » %2:mz_cluster_replica_metrics[#0{replica_id}]]
     path %0:
       after %2:
-        Project: #0, #4, #10..=#13
-        Map: ((uint8_to_double(#5{cpu_nano_cores}) / uint8_to_double(case when (0 = uint8_to_numeric(#1{cpu_nano_cores})) then null else #1{cpu_nano_cores} end)) * 100), ((uint8_to_double(#6{memory_bytes}) / uint8_to_double(case when (0 = uint8_to_numeric(#2{memory_bytes})) then null else #2{memory_bytes} end)) * 100), ((uint8_to_double(#7{disk_bytes}) / uint8_to_double(case when (0 = uint8_to_numeric(#3{disk_bytes})) then null else #3{disk_bytes} end)) * 100), ((uint8_to_double(#8{heap_bytes}) / uint8_to_double(case when (0 = uint8_to_numeric(#9{heap_limit})) then null else #9{heap_limit} end)) * 100)
+        Project: #0, #4, #11..=#13, #15, #16
+        Map: ((uint8_to_double(#5{cpu_nano_cores}) / uint8_to_double(case when (0 = uint8_to_numeric(#1{cpu_nano_cores})) then null else #1{cpu_nano_cores} end)) * 100), ((uint8_to_double(#6{memory_bytes}) / uint8_to_double(case when (0 = uint8_to_numeric(#2{memory_bytes})) then null else #2{memory_bytes} end)) * 100), ((uint8_to_double(#7{disk_bytes}) / uint8_to_double(case when (0 = uint8_to_numeric(#3{disk_bytes})) then null else #3{disk_bytes} end)) * 100), uint8_to_double(case when (0 = uint8_to_numeric(#9{heap_limit})) then null else #9{heap_limit} end), ((uint8_to_double(#8{heap_bytes}) / #14) * 100), ((uint8_to_double(#10{swap_bytes}) / #14) * 100)
     →Unarranged Raw Stream
       →Fused with Child Map/Filter/Project
         Project: #0, #3
@@ -8478,8 +8478,8 @@ Explained Query:
   →One-Shot Delta Join [%0:mz_cluster_replicas » %1:mz_cluster_replica_sizes[#0{size}] » %2:mz_cluster_replica_metrics_history[#0{replica_id}]]
     path %0:
       after %2:
-        Project: #0, #4, #11..=#14, #8
-        Map: ((uint8_to_double(#5{cpu_nano_cores}) / uint8_to_double(case when (0 = uint8_to_numeric(#1{cpu_nano_cores})) then null else #1{cpu_nano_cores} end)) * 100), ((uint8_to_double(#6{memory_bytes}) / uint8_to_double(case when (0 = uint8_to_numeric(#2{memory_bytes})) then null else #2{memory_bytes} end)) * 100), ((uint8_to_double(#7{disk_bytes}) / uint8_to_double(case when (0 = uint8_to_numeric(#3{disk_bytes})) then null else #3{disk_bytes} end)) * 100), ((uint8_to_double(#9{heap_bytes}) / uint8_to_double(case when (0 = uint8_to_numeric(#10{heap_limit})) then null else #10{heap_limit} end)) * 100)
+        Project: #0, #4, #12..=#14, #16, #17, #8
+        Map: ((uint8_to_double(#5{cpu_nano_cores}) / uint8_to_double(case when (0 = uint8_to_numeric(#1{cpu_nano_cores})) then null else #1{cpu_nano_cores} end)) * 100), ((uint8_to_double(#6{memory_bytes}) / uint8_to_double(case when (0 = uint8_to_numeric(#2{memory_bytes})) then null else #2{memory_bytes} end)) * 100), ((uint8_to_double(#7{disk_bytes}) / uint8_to_double(case when (0 = uint8_to_numeric(#3{disk_bytes})) then null else #3{disk_bytes} end)) * 100), uint8_to_double(case when (0 = uint8_to_numeric(#10{heap_limit})) then null else #10{heap_limit} end), ((uint8_to_double(#9{heap_bytes}) / #15) * 100), ((uint8_to_double(#11{swap_bytes}) / #15) * 100)
     →Unarranged Raw Stream
       →Fused with Child Map/Filter/Project
         Project: #0, #3
@@ -10527,7 +10527,7 @@ Explained Query:
       →Differential Join %0:l4[#0{entity_name}, #1{name}] » %1[#0{entity_name}, #1{column_name}]
         →Arranged l4
         →Arrange (#0{entity_name}, #1{column_name})
-          →Constant (283 rows)
+          →Constant (284 rows)
   →Return
     →Union
       →Map/Filter/Project

--- a/test/sqllogictest/mz_catalog_server_index_accounting.slt
+++ b/test/sqllogictest/mz_catalog_server_index_accounting.slt
@@ -274,6 +274,7 @@ mz_cluster_replica_metrics  heap_limit
 mz_cluster_replica_metrics  memory_bytes
 mz_cluster_replica_metrics  process_id
 mz_cluster_replica_metrics  replica_id
+mz_cluster_replica_metrics  swap_bytes
 mz_cluster_replica_metrics_history  cpu_nano_cores
 mz_cluster_replica_metrics_history  disk_bytes
 mz_cluster_replica_metrics_history  heap_bytes
@@ -282,6 +283,7 @@ mz_cluster_replica_metrics_history  memory_bytes
 mz_cluster_replica_metrics_history  occurred_at
 mz_cluster_replica_metrics_history  process_id
 mz_cluster_replica_metrics_history  replica_id
+mz_cluster_replica_metrics_history  swap_bytes
 mz_cluster_replica_name_history  id
 mz_cluster_replica_name_history  new_name
 mz_cluster_replica_name_history  occurred_at

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -410,7 +410,7 @@ ORDER BY r.id;
 ----
 Explained Query:
   Finish order_by=[#0{id} asc nulls_last] output=[#0..=#5]
-    Project (#11{id}, #12{name}, #0{id}, #14{size}, #1{name}, #29)
+    Project (#11{id}, #12{name}, #0{id}, #14{size}, #1{name}, #30)
       Map (((uint8_to_double(#25{memory_bytes}) / uint8_to_double(case when (0 = uint8_to_numeric(#19{memory_bytes})) then null else #19{memory_bytes} end)) * 100))
         Join on=(#0{id} = #13{cluster_id} AND #11{id} = #22{replica_id} AND #14{size} = #15{size}) type=delta
           ArrangeBy keys=[[#0{id}]]


### PR DESCRIPTION
### Motivation

On swap-based replica sizes, the catalog only exposes the combined `heap_bytes` / `heap_limit`. clusterd already measures swap separately (`VmSwap` from `/proc/self/status`) and reports it as `swap_bytes` on `/api/usage-metrics`, but the Kubernetes orchestrator folds it into `heap_bytes` (and, for compatibility, into `disk_bytes`) and drops the standalone value, so it never reaches SQL.

Deriving it downstream is unreliable: `heap_bytes - memory_bytes` mixes clusterd's VmRSS with the metrics-server working set (different instruments, different sampling instants), and `disk_bytes` only equals swap on swap-enabled sizes, which are not distinguishable from public catalog relations. Recording swap first-class lets the Console show how much of a replica's memory is spilled to disk. Fixes [CNS-154](https://linear.app/materializeinc/issue/CNS-154/add-swap-metrics-to-database-catalog)

### Description

* Add `swap_bytes` to `ServiceProcessMetrics`. The Kubernetes orchestrator keeps the clusterd-reported value (the existing swap-into-`disk_bytes` shim is unchanged); the process orchestrator reports `None`.
* Append `swap_bytes` as a nullable `uint8` column at the end of `REPLICA_METRICS_HISTORY_DESC`. This is a backward-compatible persist schema change, so existing history is preserved and older rows read `NULL` (same pattern as `heap_bytes` / `heap_limit` in 96fa447160).
* Record it in `mz_internal.mz_cluster_replica_metrics_history` and expose it on `mz_internal.mz_cluster_replica_metrics`.
* Add `swap_percent` to `mz_internal.mz_cluster_replica_utilization` and `mz_cluster_replica_utilization_history`, computed as `swap_bytes / heap_limit * 100`.

No clusterd changes are needed: every running clusterd already reports `swap_bytes`, so the metric lights up on existing replicas as soon as environmentd upgrades.

Two decisions worth reviewer attention:

* **`swap_percent` denominator**: `heap_limit`, matching the sibling columns' "percent of the total allocation" contract, so `heap_percent - swap_percent` reads as the RAM share and the two stack in a gauge. The spill fraction (swap as a share of `heap_bytes`) is derivable as `swap_percent / heap_percent` or from the raw columns.
* **Follow-up**: once the Console reads `swap_bytes` directly, the orchestrator shim that folds swap into `disk_bytes` can be retired (see the comment in `get_metrics`).

### Verification

Regenerated the explain goldens (`system-cluster.slt`, `catalog_server_explain.slt`) and `autogenerated/mz_internal.slt`, and added the new columns to `mz_catalog_server_index_accounting.slt`; all four files pass against a fresh catalog. The system-catalog docs page is updated to match the column comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
