### PR TITLE
ci: tolerate a bench checkout with no targets in the cargo-bench step

### DIFF
--- a/test/cargo-bench/mzcompose.py
+++ b/test/cargo-bench/mzcompose.py
@@ -608,7 +608,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             ancestor_built_raw, ancestor_build_failures = build_benches(
                 src, ancestor_targets, ancestor_manifests, ancestor_env
             )
-            target.rename(ancestor_target)
+            # A checkout without bench targets for the shard's packages runs
+            # no cargo build, and `cargo metadata` alone does not create the
+            # target dir, so there is nothing to park.
+            if target.exists():
+                target.rename(ancestor_target)
             target_owner = None
             # Keeps the checkout registered and valid so its bench binaries,
             # which read fixtures relative to their manifest dir, keep
@@ -644,7 +648,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             head_built_raw, current_build_failures = build_benches(
                 src, current_targets, current_manifests, current_env
             )
-            target.rename(current_target)
+            if target.exists():
+                target.rename(current_target)
             target_owner = None
             head_built = [
                 BuiltBench(


### PR DESCRIPTION
### Motivation

Follow-up to #38652 from its post-merge review. When the ancestor has no bench target for a shard's packages, which is the case for the first nightly after a crate gains its first `[[bench]]`, `build_benches` returns without invoking cargo, the fixed target dir is never created, and parking it raises `FileNotFoundError`. The shard dies before benchmarking anything. The same holds on the current side when the committed HEAD lacks a bench the enumerating checkout has.

### Description

Both renames now skip a target dir that was never created. Targets without an ancestor counterpart run without a baseline and are reported as new, which was the intended behavior.

Reproduced on `main` with `--package mz-ore --ancestor cc64d57df9^`, the commit before mz-ore's first bench: `FileNotFoundError` right after the ancestor phase. With the fix the same invocation builds HEAD only and reports all 55 mz-ore benchmarks as new.

---
Posted by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)