### PR TITLE
release: mark v26.40 and v26.41 as released

### DIFF
--- a/doc/user/content/releases/v26.40.md
+++ b/doc/user/content/releases/v26.40.md
@@ -1,9 +1,8 @@
 ---
 title: Materialize v26.40
 date: 2026-09-02
-released: false
+released: true
 patch: 0
-rc: 1
 publish_helm_chart: true
 build:
   render: never

--- a/doc/user/content/releases/v26.41.md
+++ b/doc/user/content/releases/v26.41.md
@@ -1,9 +1,8 @@
 ---
 title: Materialize v26.41
 date: 2026-09-09
-released: false
+released: true
 patch: 0
-rc: 1
 publish_helm_chart: true
 build:
   render: never


### PR DESCRIPTION
Restores the two `released: true` marks that [`mark_release_complete.py`](https://github.com/MaterializeInc/materialize/blob/main/misc/python/materialize/release/mark_release_complete.py) made but could not push. Same situation, and same cause, as #38783 and #38567.

## What happened

`complete-release.yml` runs weekly (1am UTC Thursdays) and ends with `git push origin main`, which branch protection now refuses:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
```

- [09-03 run](https://github.com/MaterializeInc/release/actions/runs/33703538642) — `Version: v26.40, Patch: 0`, `release: mark v26.40 as released`, push rejected
- [09-10 run](https://github.com/MaterializeInc/release/actions/runs/34424948385) — `Version: v26.41, Patch: 0`, `release: mark v26.41 as released`, push rejected

Last success was 08-27 for v26.39, which is exactly where `released: true` stops in `doc/user/content/releases/`.

Both commits here reproduce what those runs computed: `released: true`, `patch: 0` (derived from `Pulumi.production.yaml`'s pinned `environmentd_image_ref` at the time each ran), and the `rc` key dropped. Applied with the same `frontmatter` load/dump the script uses rather than by hand, so the serialization matches; the resulting frontmatter is identical in shape to `v26.39.md`.

## Why it matters

`released: true` is the gate for `VersionsFromDocs(respect_released_tag=True)`, and two things consume it:

- **Cloud upgrade tests.** `tests/k8s/test_environment.py::calculate_images` builds its image set from `VersionsFromDocs(respect_released_tag=True).minor_versions()`, so with v26.40 and v26.41 unmarked it has been testing upgrades from v26.39 and older.
- **GitHub releases.** `ci/deploy/github_release.py` gates on the same flag. The tags `v26.40.0` and `v26.41.0` exist but no release objects were ever created — v26.39.0 is still showing as "Latest".

## Note on `patch`

Both commits set `patch: 0`, which is what each run computed from production's pin at the time. v26.40.1 and v26.40.2 shipped afterwards, and `mark_release_complete` is the only writer of that field and only runs once per minor version, so nothing would have raised v26.40's `patch` to 2 even without this failure. Left as-is here rather than invented, but worth a look separately — `VersionsFromDocs` enumerates `range(patch + 1)`, so published patch releases are currently not enumerated.

## Follow-up

Three workflows push directly to `materialize` main — `cut-release`, `complete-release`, and the helm-chart publish's `latest_versions.yml` bump. The first two have failed every week since 08-28. This recurs until they open a PR instead, or `materialize-bot` gets a branch-protection bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzQZdcie5q75t4NJjUQDeB
