### PR TITLE
ci: make the Console SQL suite survive a degraded agent

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -770,6 +770,15 @@ steps:
           queue: hetzner-x86-64-16cpu-32gb
         coverage: skip
         sanitizer: skip
+        # Every test in this suite carries a wall-clock budget sized against a
+        # healthy agent. A degraded one dilates the whole job uniformly, tests
+        # and `yarn install` alike, far enough to blow those budgets while
+        # Materialize itself is healthy. Raising the budgets is not the answer:
+        # a dilated run already spends most of the step timeout.
+        retry:
+          automatic:
+            - exit_status: 1
+              limit: 1
 
       - id: console-e2e-test
         label: "Console E2E/staging"

--- a/console/src/platform/shell/useClusterDropdown.test.sql.ts
+++ b/console/src/platform/shell/useClusterDropdown.test.sql.ts
@@ -13,6 +13,13 @@ import { buildClustersQuery } from "~/api/materialize/cluster/clusterList";
 import { getMaterializeClient } from "~/test/sql/materializeSqlClient";
 import { testdrive } from "~/test/sql/mzcompose";
 
+/**
+ * How long to keep fetching before asserting on whatever the subscribe produced.
+ * Stays below the suite's `testTimeout` so a snapshot that never arrives fails on
+ * the assertion, which names the missing cluster, rather than on the test timeout.
+ */
+const SUBSCRIBE_SNAPSHOT_TIMEOUT_MS = 30_000;
+
 describe("useClustersDropdown subscribe", () => {
   it("subscribes to non-system clusters", async () => {
     // reset Materialize state
@@ -27,9 +34,22 @@ describe("useClustersDropdown subscribe", () => {
     ).compile(queryBuilder);
     await client.query("BEGIN");
     await client.query(`DECLARE c CURSOR FOR ${sql}`, parameters as string[]);
-    const result = await client.query(`FETCH ALL c WITH (timeout='1s')`);
+    // A single FETCH window is a wall-clock budget for work whose duration the
+    // test does not control: optimizing the subscribe and computing its snapshot.
+    // On a loaded CI agent that exceeds a second, and the assertion below then
+    // sees an empty snapshot rather than a wrong one. Keep fetching until the
+    // cluster arrives, so the test waits on the signal it is about to assert on
+    // instead of on the clock.
+    const clusters: Record<string, unknown>[] = [];
+    const deadline = Date.now() + SUBSCRIBE_SNAPSHOT_TIMEOUT_MS;
+    do {
+      const result = await client.query(`FETCH ALL c WITH (timeout='1s')`);
+      clusters.push(...result.rows.filter((r) => r["mz_state"] === "upsert"));
+    } while (
+      !clusters.some((r) => r["name"] === "quickstart") &&
+      Date.now() < deadline
+    );
     await client.query("COMMIT");
-    const clusters = result.rows.filter((r) => r["mz_state"] === "upsert");
     expect(clusters).toContainEqual({
       mz_timestamp: expect.any(String),
       mz_progressed: false,


### PR DESCRIPTION
Every test in the console SQL suite carries a wall-clock budget sized against a healthy agent, and one test additionally budgets its subscribe snapshot at a fixed second. Build 134474 landed on an agent that ran 6-12x slow and four tests failed: three on the 45 second per-test timeout, and `useClustersDropdown subscribe` on an empty snapshot. The dilation was uniform across work Materialize does and work it does not, so the cause was the agent rather than the code under test.

Comparing that build against the previous passing run of the same suite, on the same branch and the same 87 testdrive resets:

| measurement | passing run | failing run | ratio |
|---|---|---|---|
| `yarn install` fetch step | 5.3 s | 32.1 s | 6.0x |
| `yarn install` link step | 7.8 s | 51.3 s | 6.6x |
| testdrive reset, median | 0.36 s | 4.42 s | 12x |
| testdrive reset, total | 32.7 s | 403.5 s | 12x |
| whole vitest suite | 147.9 s | 1281.8 s | 8.7x |

`yarn install` never touches Materialize and still slowed 6x, which is what rules out a regression in the code under test.

Make the dropdown test poll the subscribe cursor until the cluster it asserts on arrives, instead of reading one one-second `FETCH` window and asserting on whatever that returned. Optimizing the subscribe and computing its snapshot is work whose duration the test does not control, and peek optimization alone reached 2.3 seconds in that run, so the old budget could not hold. The poll stops at 30 seconds, below the suite's `testTimeout`, so a snapshot that genuinely never arrives still fails on the assertion and names the missing cluster.

Retry the step once for the rest. Their budgets are not the problem: a dilated run already spends 25.5 of the step's 30 minutes, so raising them converts test failures into step timeouts, and the suite's largest fixed cost, 403 seconds of catalog resets in that run, is too small to close a gap that size. A retry does mean a genuine console regression is attempted twice before the step goes red.

Modified `console/src/platform/shell/useClusterDropdown.test.sql.ts`, the test that was failing. No new tests: the change makes an existing test wait on the signal it asserts on rather than on the clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)