### PR TITLE
adapter: authorize dependent secrets before altering connections

### DIFF
--- a/doc/developer/guide-adapter.md
+++ b/doc/developer/guide-adapter.md
@@ -215,6 +215,15 @@ fixed connection does not authorize its dependencies separately. For example,
 standalone `VALIDATE CONNECTION` is delegated by `USAGE` on the connection and
 its containing schema, without requiring `USAGE` on referenced secrets.
 
+Changing a connection also changes the effective configuration of dependent
+connections. `Coordinator::check_alter_connection_usage` requires `USAGE` on
+every secret reachable through those connections, including connections with no
+active source or sink. Route ownership alone does not delegate authority over
+dependent credentials. This check precedes secret reads and validation and runs
+again before persistence, because dependents and grants can change during
+external validation. Dependency traversal uses the altered connection's final
+definition so removing an inaccessible dependency remains possible.
+
 ### The catalog is the source of truth for state that gets rebuilt from it
 
 If a reconcile or refresh path rebuilds downstream state (for example a

--- a/doc/user/content/headless/sql-command-privileges/alter-connection.md
+++ b/doc/user/content/headless/sql-command-privileges/alter-connection.md
@@ -7,7 +7,19 @@ headless: true
     resulting connection definition.
   - `USAGE` privileges on the schemas that contain those connections and
     secrets.
+  - `USAGE` privileges on secrets used directly or transitively by dependent
+    connections, and on the schemas containing those secrets. This applies even
+    when the dependent connection has no active source or sink and validation is
+    disabled.
 - In addition, to change owners:
   - Role membership in `new_owner`.
   - `CREATE` privileges on the containing schema if the connection is namespaced
   by a schema.
+
+Owning a shared SSH tunnel or AWS PrivateLink connection does not grant authority
+to redirect credentials used by its dependent connections. A dependent connection
+whose secrets the route owner cannot use prevents that owner from altering route
+options. Grant the route administrator access to those secrets, have an authorized
+role alter the route, or remove the dependency before altering it. `USAGE` on an
+unchanged connection still permits `VALIDATE CONNECTION` without access to its
+secrets.

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3793,20 +3793,8 @@ impl Coordinator {
             }
         };
 
-        // Replanning uses a system session and discovers retained dependencies
-        // that `check_plan` could not authorize. Check them before secret guards
-        // or validation can resolve a secret.
-        let usage_check = {
-            let catalog = self.catalog().for_session(ctx.session());
-            rbac::check_usage(
-                &catalog,
-                ctx.session(),
-                &conn.resolved_ids,
-                &rbac::CREATE_ITEM_USAGE,
-            )
-        };
-        if let Err(err) = usage_check {
-            return ctx.retire(Err(err.into()));
+        if let Err(err) = self.check_alter_connection_usage(ctx.session(), id, &conn) {
+            return ctx.retire(Err(err));
         }
 
         // `conn` is the whole re-planned connection, so this also rejects a
@@ -3889,6 +3877,53 @@ impl Coordinator {
         }
     }
 
+    /// Authorizes the final definition and secrets used by connections whose
+    /// effective configuration changes with it.
+    fn check_alter_connection_usage(
+        &self,
+        session: &Session,
+        id: CatalogItemId,
+        connection: &Connection,
+    ) -> Result<(), AdapterError> {
+        let catalog = self.catalog().for_session(session);
+        let mut usage_ids = connection.resolved_ids.clone();
+
+        // A route's own definition can contain no secrets even though changing
+        // it redirects credentials in dependent connections. Include unused
+        // connections because delegated validation can activate them later.
+        let mut pending: Vec<_> = catalog
+            .item_dependents(id)
+            .into_iter()
+            .filter_map(|object_id| match object_id {
+                ObjectId::Item(id) if self.catalog().get_entry(&id).connection().is_ok() => {
+                    Some(id)
+                }
+                _ => None,
+            })
+            .collect();
+        let mut visited = BTreeSet::new();
+        while let Some(dependency_id) = pending.pop() {
+            if !visited.insert(dependency_id) {
+                continue;
+            }
+            let entry = self.catalog().get_entry(&dependency_id);
+            match entry.item() {
+                CatalogItem::Connection(conn) => {
+                    let conn = if dependency_id == id {
+                        connection
+                    } else {
+                        conn
+                    };
+                    pending.extend(conn.resolved_ids.items().copied());
+                }
+                CatalogItem::Secret(_) => usage_ids.add_item(dependency_id),
+                _ => (),
+            }
+        }
+        rbac::check_usage(&catalog, session, &usage_ids, &rbac::CREATE_ITEM_USAGE)?;
+        Ok(())
+    }
+
     #[instrument]
     pub(crate) async fn sequence_alter_connection_stage_finish(
         &mut self,
@@ -3896,6 +3931,9 @@ impl Coordinator {
         id: CatalogItemId,
         connection: Connection,
     ) -> Result<ExecuteResponse, AdapterError> {
+        // Dependents and grants can change while external validation runs.
+        self.check_alter_connection_usage(session, id, &connection)?;
+
         match self.catalog.get_entry(&id).item() {
             CatalogItem::Connection(curr_conn) => {
                 curr_conn

--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -161,6 +161,251 @@ REVOKE USAGE ON SCHEMA materialize.public FROM joe;
 ----
 COMPLETE 0
 
+# Shared routes must authorize their dependents' secrets even when the route
+# itself has no dependencies and the dependent has no active source or sink.
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON SCHEMA materialize.public TO joe;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET max_aws_privatelink_connections = 5;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE CONNECTION ssh_route TO SSH TUNNEL (HOST 'original.invalid', USER 'mz');
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER CONNECTION ssh_route OWNER TO joe;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE SECRET ssh_route_password AS 'secret';
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE CONNECTION ssh_route_pg TO POSTGRES (HOST 'postgres', DATABASE 'postgres', USER 'postgres', PASSWORD SECRET ssh_route_password, SSH TUNNEL ssh_route) WITH (VALIDATE = false);
+----
+COMPLETE 0
+
+# This dependent reaches the same secret through a separate AWS connection.
+simple conn=mz_system,user=mz_system
+CREATE CONNECTION ssh_route_aws TO AWS (REGION 'us-east-1', ACCESS KEY ID 'AKIAEXAMPLE', SECRET ACCESS KEY SECRET ssh_route_password) WITH (VALIDATE = false);
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE CONNECTION ssh_route_kafka TO KAFKA (BROKER 'broker:9092' USING SSH TUNNEL ssh_route, SECURITY PROTOCOL SASL_PLAINTEXT, AWS CONNECTION ssh_route_aws) WITH (VALIDATE = false);
+----
+COMPLETE 0
+
+simple conn=joe,user=joe
+ALTER CONNECTION ssh_route SET (HOST 'redirected.invalid') WITH (VALIDATE = false);
+----
+db error: ERROR: permission denied for SECRET "materialize.public.ssh_route_password"
+DETAIL: The 'joe' role needs USAGE privileges on SECRET "materialize.public.ssh_route_password"
+
+simple conn=joe,user=joe
+ALTER CONNECTION ssh_route SET (HOST 'redirected.invalid') WITH (VALIDATE = true);
+----
+db error: ERROR: permission denied for SECRET "materialize.public.ssh_route_password"
+DETAIL: The 'joe' role needs USAGE privileges on SECRET "materialize.public.ssh_route_password"
+
+simple conn=mz_system,user=mz_system
+SELECT create_sql LIKE '%original.invalid%' FROM mz_connections WHERE name = 'ssh_route';
+----
+t
+COMPLETE 1
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON SECRET ssh_route_password TO other;
+----
+COMPLETE 0
+
+simple conn=child,user=child
+ALTER CONNECTION ssh_route SET (HOST 'redirected.invalid') WITH (VALIDATE = false);
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+REVOKE USAGE ON SECRET ssh_route_password FROM other;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER CONNECTION ssh_route_pg OWNER TO joe;
+----
+COMPLETE 0
+
+simple conn=joe,user=joe
+ALTER CONNECTION ssh_route SET (HOST 'redirected.invalid') WITH (VALIDATE = false);
+----
+db error: ERROR: permission denied for SECRET "materialize.public.ssh_route_password"
+DETAIL: The 'joe' role needs USAGE privileges on SECRET "materialize.public.ssh_route_password"
+
+simple conn=joe,user=joe
+DROP CONNECTION ssh_route_pg;
+----
+COMPLETE 0
+
+simple conn=joe,user=joe
+ALTER CONNECTION ssh_route SET (HOST 'redirected.invalid') WITH (VALIDATE = false);
+----
+db error: ERROR: permission denied for SECRET "materialize.public.ssh_route_password"
+DETAIL: The 'joe' role needs USAGE privileges on SECRET "materialize.public.ssh_route_password"
+
+simple conn=mz_system,user=mz_system
+DROP CONNECTION ssh_route_kafka;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+DROP CONNECTION ssh_route_aws;
+----
+COMPLETE 0
+
+simple conn=joe,user=joe
+ALTER CONNECTION ssh_route SET (HOST 'redirected.invalid') WITH (VALIDATE = false);
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+DROP CONNECTION ssh_route;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+DROP SECRET ssh_route_password;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE CONNECTION private_route TO AWS PRIVATELINK (SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc', AVAILABILITY ZONES ('use1-az1'));
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER CONNECTION private_route OWNER TO joe;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE SECRET private_route_password AS 'secret';
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE CONNECTION private_route_pg TO POSTGRES (HOST 'postgres', DATABASE 'postgres', USER 'postgres', PASSWORD SECRET private_route_password, AWS PRIVATELINK private_route) WITH (VALIDATE = false);
+----
+COMPLETE 0
+
+# This dependent reaches the same secret through a separate AWS connection.
+simple conn=mz_system,user=mz_system
+CREATE CONNECTION private_route_aws TO AWS (REGION 'us-east-1', ACCESS KEY ID 'AKIAEXAMPLE', SECRET ACCESS KEY SECRET private_route_password) WITH (VALIDATE = false);
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE CONNECTION private_route_kafka TO KAFKA (BROKER 'broker:9092' USING AWS PRIVATELINK private_route, SECURITY PROTOCOL SASL_PLAINTEXT, AWS CONNECTION private_route_aws) WITH (VALIDATE = false);
+----
+COMPLETE 0
+
+simple conn=joe,user=joe
+ALTER CONNECTION private_route SET (SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abd') WITH (VALIDATE = false);
+----
+db error: ERROR: permission denied for SECRET "materialize.public.private_route_password"
+DETAIL: The 'joe' role needs USAGE privileges on SECRET "materialize.public.private_route_password"
+
+simple conn=joe,user=joe
+ALTER CONNECTION private_route SET (SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abd') WITH (VALIDATE = true);
+----
+db error: ERROR: permission denied for SECRET "materialize.public.private_route_password"
+DETAIL: The 'joe' role needs USAGE privileges on SECRET "materialize.public.private_route_password"
+
+simple conn=mz_system,user=mz_system
+SELECT create_sql LIKE '%vpce-svc-0e123abc123198abc%' FROM mz_connections WHERE name = 'private_route';
+----
+t
+COMPLETE 1
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON SECRET private_route_password TO other;
+----
+COMPLETE 0
+
+simple conn=child,user=child
+ALTER CONNECTION private_route SET (SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abd') WITH (VALIDATE = false);
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+REVOKE USAGE ON SECRET private_route_password FROM other;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER CONNECTION private_route_pg OWNER TO joe;
+----
+COMPLETE 0
+
+simple conn=joe,user=joe
+ALTER CONNECTION private_route SET (SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abd') WITH (VALIDATE = false);
+----
+db error: ERROR: permission denied for SECRET "materialize.public.private_route_password"
+DETAIL: The 'joe' role needs USAGE privileges on SECRET "materialize.public.private_route_password"
+
+simple conn=joe,user=joe
+DROP CONNECTION private_route_pg;
+----
+COMPLETE 0
+
+simple conn=joe,user=joe
+ALTER CONNECTION private_route SET (SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abd') WITH (VALIDATE = false);
+----
+db error: ERROR: permission denied for SECRET "materialize.public.private_route_password"
+DETAIL: The 'joe' role needs USAGE privileges on SECRET "materialize.public.private_route_password"
+
+simple conn=mz_system,user=mz_system
+DROP CONNECTION private_route_kafka;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+DROP CONNECTION private_route_aws;
+----
+COMPLETE 0
+
+simple conn=joe,user=joe
+ALTER CONNECTION private_route SET (SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abd') WITH (VALIDATE = false);
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+DROP CONNECTION private_route;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+DROP SECRET private_route_password;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET max_aws_privatelink_connections;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+REVOKE USAGE ON SCHEMA materialize.public FROM joe;
+----
+COMPLETE 0
+
 # CREATE DATABASE
 
 simple conn=joe,user=joe

--- a/test/ssh-connection/pg-source.td
+++ b/test/ssh-connection/pg-source.td
@@ -29,6 +29,26 @@ contains: HOST specified more than once
     SSH TUNNEL thancred
   );
 
+# The route owner can use the fixed connection without authority to redirect
+# its password, including before there is an active source.
+$ postgres-execute connection=mz_system
+ALTER SYSTEM SET enable_rbac_checks = true;
+ALTER SECRET pgpass OWNER TO mz_system;
+CREATE ROLE route_validator_${testdrive.seed} LOGIN PASSWORD 'validatorpass';
+GRANT USAGE ON SCHEMA materialize.public TO route_validator_${testdrive.seed};
+GRANT USAGE ON CONNECTION pg TO route_validator_${testdrive.seed};
+
+! ALTER CONNECTION thancred SET (HOST 'redirected.invalid') WITH (VALIDATE = false)
+contains:permission denied for SECRET "materialize.public.pgpass"
+
+! ALTER CONNECTION thancred SET (HOST 'redirected.invalid') WITH (VALIDATE = true)
+contains:permission denied for SECRET "materialize.public.pgpass"
+
+$ postgres-connect name=route_validator url=postgres://route_validator_${testdrive.seed}:validatorpass@${testdrive.materialize-sql-addr}
+
+$ postgres-execute connection=route_validator
+VALIDATE CONNECTION pg;
+
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;
 DROP SCHEMA IF EXISTS public CASCADE;
@@ -55,6 +75,12 @@ true
 > SELECT f1 FROM t1;
 1
 
+! ALTER CONNECTION thancred SET (HOST 'redirected.invalid') WITH (VALIDATE = false)
+contains:permission denied for SECRET "materialize.public.pgpass"
+
+$ postgres-execute connection=route_validator
+VALIDATE CONNECTION pg;
+
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 INSERT INTO t1 VALUES (1), (2);
 
@@ -62,3 +88,17 @@ INSERT INTO t1 VALUES (1), (2);
 1
 1
 2
+
+# Granting secret access permits route administration with an active dependent.
+$ postgres-execute connection=mz_system
+GRANT USAGE ON SECRET pgpass TO materialize;
+
+> ALTER CONNECTION thancred SET (HOST 'ssh-bastion-host') WITH (VALIDATE = true)
+
+> SELECT f1 FROM t1 ORDER BY f1 ASC;
+1
+1
+2
+
+$ postgres-execute connection=mz_system
+ALTER SECRET pgpass OWNER TO materialize;


### PR DESCRIPTION
### Motivation

Changing a shared SSH tunnel or AWS PrivateLink connection can redirect credentials used by dependent connections even when the route owner cannot use those credentials' secrets.

Closes: [SQL-662](https://linear.app/materializeinc/issue/SQL-662)

### Description

Require `USAGE` on secrets used directly or transitively by dependent connections before changing connection options. Authorization includes unused connections because delegated validation can activate them later. Retain the existing checks on the altered connection's final dependencies, so removing an inaccessible dependency remains possible.

Check authorization before secret inspection or external validation, and repeat it before catalog persistence to account for dependents or grants changed during validation. Route ownership alone does not delegate authority over dependent credentials. The privilege documentation explains that an inaccessible dependent secret blocks route administration and describes how to resolve that restriction.

### Verification

Extend the SQL privilege tests for SSH and AWS PrivateLink routes with empty own dependency sets, direct and indirect secret dependencies, inherited privileges, ownership transfers, dependency removal, and unchanged catalog definitions after rejected alterations.

Extend the SSH/Postgres integration test to cover delegated validation before source creation, rejection with an active source, continued ingestion, and authorized route administration after a secret grant. Execution of this Docker integration coverage is pending.

Repository lint reports pre-existing unpinned `actions/checkout@v4` references in the unchanged [QA notification workflow](https://github.com/MaterializeInc/materialize/blob/7c9162cfb1/.github/workflows/slack_notify_qa_risky.yml#L67) and [SQL parser notification workflow](https://github.com/MaterializeInc/materialize/blob/7c9162cfb1/.github/workflows/slack_notify_sql_parser.yml#L68).
