### PR TITLE
compute: route the recursion limit by each update's own time

### DIFF
--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -147,10 +147,11 @@ use mz_timely_util::operator::{CollectionExt, StreamExt};
 use mz_timely_util::probe::{Handle as MzProbeHandle, ProbeNotify};
 use mz_timely_util::scope_label::ScopeExt;
 use timely::PartialOrder;
+use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::core::to_stream::ToStreamBuilder;
+use timely::dataflow::operators::vec::Filter;
 use timely::dataflow::operators::vec::ToStream;
-use timely::dataflow::operators::vec::{BranchWhen, Filter};
 use timely::dataflow::operators::{Capability, Operator, Probe, probe};
 use timely::dataflow::{Scope, Stream, StreamVec};
 use timely::order::{Product, TotalOrder};
@@ -1006,13 +1007,23 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 if let Some(limit) = limit {
                     // We swallow the results of the `max_iter`th iteration, because
                     // these results would go into the `max_iter + 1`th iteration.
-                    let (in_limit, over_limit) =
-                        oks.inner.branch_when(move |Product { inner: ps, .. }| {
-                            // The iteration number, or if missing a zero (as trailing zeros are truncated).
-                            let iteration_index = *ps.get(level).unwrap_or(&0);
-                            // The pointstamp starts counting from 0, so we need to add 1.
-                            iteration_index + 1 >= limit.max_iters.into()
-                        });
+                    //
+                    // The split consults each update's own time. A container's capability
+                    // is only a lower bound on the times it carries, so deciding per
+                    // container by capability could retain updates from an iteration
+                    // beyond the one the capability names.
+                    let (over_limit, in_limit) = oks
+                        .inner
+                        .partition_by::<CapacityContainerBuilder<Vec<_>>, _>(
+                            "LetRecLimit",
+                            move |(_data, Product { inner: ps, .. }, _diff)| {
+                                // The iteration number, or zero if absent, since trailing zero
+                                // coordinates are truncated.
+                                let iteration_index = *ps.get(level).unwrap_or(&0);
+                                // The pointstamp starts counting from 0, so we need to add 1.
+                                iteration_index + 1 >= limit.max_iters.into()
+                            },
+                        );
                     oks = VecCollection::new(in_limit);
                     if !limit.return_at_limit {
                         err = err.concat(VecCollection::new(over_limit).map(move |_data| {

--- a/src/timely-util/src/operator.rs
+++ b/src/timely-util/src/operator.rs
@@ -98,6 +98,25 @@ where
         I: IntoIterator<Item = Result<D2, E>>,
         L: for<'a> FnMut(C1::Item<'a>) -> I + 'static;
 
+    /// Routes each record to one of two output streams by a per-record predicate.
+    ///
+    /// Records for which `predicate` returns `true` go to the first output and all
+    /// others to the second. Both outputs are sent under the input capability. That
+    /// capability is only a lower bound on the times of the records it carries, so a
+    /// split that depends on a record's time must inspect the record, and cannot be
+    /// decided once per container.
+    fn partition_by<CB, L>(
+        self,
+        name: &str,
+        predicate: L,
+    ) -> (
+        Stream<'scope, T, CB::Container>,
+        Stream<'scope, T, CB::Container>,
+    )
+    where
+        CB: ContainerBuilder + for<'a> PushInto<C1::Item<'a>>,
+        L: for<'a> FnMut(&C1::Item<'a>) -> bool + 'static;
+
     /// Block progress of the frontier at `expiration` time
     fn expire_stream_at(self, name: &str, expiration: T) -> Stream<'scope, T, C1>;
 }
@@ -295,6 +314,35 @@ where
                         match r {
                             Ok(d2) => ok_session.give(d2),
                             Err(e) => err_session.give(e),
+                        }
+                    }
+                })
+            })
+        })
+    }
+
+    fn partition_by<CB, L>(
+        self,
+        name: &str,
+        mut predicate: L,
+    ) -> (
+        Stream<'scope, T, CB::Container>,
+        Stream<'scope, T, CB::Container>,
+    )
+    where
+        CB: ContainerBuilder + for<'a> PushInto<C1::Item<'a>>,
+        L: for<'a> FnMut(&C1::Item<'a>) -> bool + 'static,
+    {
+        self.unary_fallible::<CB, CB, _, _>(Pipeline, name, move |_, _| {
+            Box::new(move |input, matching_output, rest_output| {
+                input.for_each_time(|time, data| {
+                    let mut matching = matching_output.session_with_builder(&time);
+                    let mut rest = rest_output.session_with_builder(&time);
+                    for item in data.flat_map(DrainContainer::drain) {
+                        if predicate(&item) {
+                            matching.give(item);
+                        } else {
+                            rest.give(item);
                         }
                     }
                 })
@@ -724,5 +772,81 @@ pub trait ClearContainer {
 impl<T> ClearContainer for Vec<T> {
     fn clear(&mut self) {
         Vec::clear(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use timely::container::CapacityContainerBuilder;
+    use timely::dataflow::operators::Capture;
+    use timely::dataflow::operators::capture::Extract;
+    use timely::dataflow::operators::core::to_stream::ToStreamBuilder;
+    use timely::dataflow::operators::vec::ToStream;
+
+    use crate::columnar::Column;
+    use crate::columnar::builder::ColumnBuilder;
+
+    use super::*;
+
+    /// Updates whose own times straddle `SPLIT`, all carried under the single input
+    /// capability at time zero. A split decided per container would route them together.
+    const UPDATES: [(u64, u64, i64); 4] = [(0, 0, 1), (1, 3, 1), (2, 5, -1), (3, 7, 1)];
+    const SPLIT: u64 = 5;
+    const MATCHING: [(u64, u64, i64); 2] = [(2, 5, -1), (3, 7, 1)];
+    const REST: [(u64, u64, i64); 2] = [(0, 0, 1), (1, 3, 1)];
+
+    #[mz_ore::test]
+    fn partition_by_routes_vec_records_by_their_own_time() {
+        let (matching, rest) = timely::execute_directly(|worker| {
+            worker.dataflow::<u64, _, _>(|scope| {
+                let (matching, rest) = UPDATES
+                    .to_vec()
+                    .to_stream(scope)
+                    .partition_by::<CapacityContainerBuilder<Vec<_>>, _>("Test", |(_, time, _)| {
+                        *time >= SPLIT
+                    });
+                (matching.capture(), rest.capture())
+            })
+        });
+        let flatten = |captured: Vec<(u64, Vec<(u64, u64, i64)>)>| {
+            captured
+                .into_iter()
+                .flat_map(|(capability, updates)| {
+                    assert_eq!(capability, 0, "outputs keep the input capability");
+                    updates
+                })
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(flatten(matching.extract()), MATCHING);
+        assert_eq!(flatten(rest.extract()), REST);
+    }
+
+    #[mz_ore::test]
+    fn partition_by_routes_columnar_records_by_their_own_time() {
+        let (matching, rest) = timely::execute_directly(|worker| {
+            worker.dataflow::<u64, _, _>(|scope| {
+                let (matching, rest) = UPDATES
+                    .to_vec()
+                    .to_stream_with_builder::<_, ColumnBuilder<(u64, u64, i64)>>(scope)
+                    .partition_by::<ColumnBuilder<(u64, u64, i64)>, _>("Test", |(_, time, _)| {
+                        **time >= SPLIT
+                    });
+                (matching.capture(), rest.capture())
+            })
+        });
+        let flatten = |captured: Vec<(u64, Column<(u64, u64, i64)>)>| {
+            captured
+                .into_iter()
+                .flat_map(|(capability, mut column)| {
+                    assert_eq!(capability, 0, "outputs keep the input capability");
+                    column
+                        .drain()
+                        .map(|(data, time, diff)| (*data, *time, *diff))
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(flatten(matching.extract()), MATCHING);
+        assert_eq!(flatten(rest.extract()), REST);
     }
 }


### PR DESCRIPTION
### Motivation

The `WITH MUTUALLY RECURSIVE` recursion limit splits each binding's consolidated stream into in-limit and over-limit halves with timely's `branch_when`, which routes whole containers by the container's capability. A capability is only a lower bound on the times of the updates it carries, so a container whose capability is inside the limit can carry updates from a later iteration that is not, and those updates would be retained. Nothing can be discarded incorrectly in any case: the predicate is monotone in the iteration coordinate and the capability is at or below every update.

Today the site is protected by structure rather than contract. The consolidate directly upstream seals one batch per retired capability, with the frontier and all later-held capabilities as the upper bound. For a binding whose body reaches its own variable, the feedback cycle pins the consolidate's input frontier one iteration past each held capability, so every update in a batch shares the capability's iteration coordinate. That argument does not cover a limited binding with no cycle back to itself that an earlier binding reads through its variable. There, with multiple workers, a data message can arrive ahead of the progress messages that retire the previous iteration, the consolidate's frontier can advance two iterations at once, and one batch carries both.

`branch_when` is also being removed from timely.

### Description

* Adds `StreamExt::partition_by` to `mz-timely-util`: a two-output operator that routes each record by a predicate on the record itself, built on the existing `unary_fallible`. It is generic over the container through `DrainContainer` and a `ContainerBuilder`, so the same operator serves `Vec` streams today and `Column` streams once the rec loop's consolidate moves onto the native columnar path. The outputs are `(matching, rest)`, following `Iterator::partition`.
* Uses it at the recursion-limit site, deciding on each update's own time rather than the container's capability.

This is meant to sit alongside the columnar edge work. Once the rec loop consolidates natively, the call site changes only its builder type and the predicate's field access.

### Verification

Two unit tests in `mz-timely-util` push updates whose own times straddle the split under a single capability, once as a `Vec` container and once as a `Column`, and check that they are routed by their own time with the input capability kept. The existing `with_mutually_recursive.slt` covers the limit semantics end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
