### PR TITLE
ci: pull the MinIO images from quay.io

### DIFF
--- a/misc/python/materialize/cloudtest/k8s/minio-yaml/minio-standalone-deployment.yaml
+++ b/misc/python/materialize/cloudtest/k8s/minio-yaml/minio-standalone-deployment.yaml
@@ -23,8 +23,11 @@ spec:
           claimName: minio-pv-claim
       containers:
       - name: minio
-        # Pulls the default Minio image from Docker Hub
-        image: minio/minio:latest
+        # Pulled from quay.io because MinIO deleted the Docker Hub repository,
+        # which 404s. Pinned to the last AGPL community release rather than
+        # tracking a tag: the same repository also carries MinIO's commercial
+        # `.hotfix.<sha>` builds, which carry different licence terms.
+        image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
         args:
         - server
         - /storage

--- a/misc/python/materialize/cloudtest/k8s/minio.py
+++ b/misc/python/materialize/cloudtest/k8s/minio.py
@@ -96,7 +96,7 @@ class Minio(K8sResource):
         self.kubectl(
             "run",
             "minio",
-            "--image=minio/mc:RELEASE.2023-07-07T05-25-51Z",
+            "--image=quay.io/minio/mc:RELEASE.2023-07-07T05-25-51Z",
             "--restart=Never",
             "--command",
             "/bin/sh",

--- a/misc/python/materialize/mzcompose/services/minio.py
+++ b/misc/python/materialize/mzcompose/services/minio.py
@@ -64,10 +64,16 @@ class Minio(Service):
 
 
 class Mc(Service):
+    # `mc` comes from quay.io because MinIO deleted `minio/mc` and
+    # `minio/minio` from Docker Hub, where both repositories 404. An
+    # unqualified image name resolves to Docker Hub and fails with "pull access
+    # denied", which reads like a credentials problem rather than a missing
+    # repository. The upstream source repository is archived and its final tag
+    # is the one pinned here, so there is no newer release to move to.
     def __init__(
         self,
         name: str = "mc",
-        image: str = "minio/mc:RELEASE.2025-08-13T08-35-41Z",
+        image: str = "quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z",
     ) -> None:
         super().__init__(
             name=name,


### PR DESCRIPTION
MinIO deleted the `minio/mc` and `minio/minio` repositories from Docker Hub, where both now 404 at the repository level. An unqualified image name resolves to Docker Hub, so every composition that starts the `mc` service fails its pull:

```
Image minio/mc:RELEASE.2025-08-13T08-35-41Z  Error pull access denied for minio/mc,
repository does not exist or may require 'docker login'
```

That message reads like a credentials problem rather than a missing repository, which is Docker Hub's generic response for a repository that is not there. Twelve compositions declare the `mc` service, including platform-checks, zippy, parallel-workload and feature-benchmark.

Qualify the three image references with quay.io, which still serves the pinned tags. This changes only where the bytes come from: each tag resolves to the same release as before, and the `mc` tags are multi-architecture manifest lists. All three were verified by pulling them.

Pin the cloudtest deployment to the last AGPL community release instead of tracking `latest`. That repository also carries MinIO's commercial `.hotfix.<sha>` builds, which come with different licence terms, so a floating tag is a way to end up on one without noticing.

### What this does not fix

Both upstream source repositories are now archived, and each tag pinned here is at or near the final community release, so there is nothing newer to move to. quay.io is the same vendor's other registry, so this trades one single point of failure for another; MinIO has already demonstrated they will delete a registry. The durable options, neither taken here, are to build `mc` from its archived source as an mzbuild image the way `test/minio/Dockerfile` already does for the server, or to move off MinIO entirely.

The MinIO server is unaffected in the mzcompose path: `test/minio/Dockerfile` builds it from source at a pinned tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)