### PR TITLE
ci: merge the shared infra retries into a step's own retry rules

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -759,33 +759,47 @@ def permit_rerunning_successful_steps(pipeline: Any) -> None:
         )
 
 
+# Failures that are the infrastructure's fault rather than the step's, so every
+# step retries them regardless of what else it asks for.
+SHARED_AUTOMATIC_RETRIES = [
+    {
+        "exit_status": -1,
+        "signal_reason": "none",
+        "limit": 2,
+    },
+    {
+        "signal_reason": "agent_stop",  # Stopped by OS
+        "limit": 2,
+    },
+    {
+        "exit_status": 128,  # Temporary Github/GHCR/DockerHub connection issue
+        "limit": 2,
+    },
+    {
+        "exit_status": 199,  # Rust ICE https://github.com/rust-lang/rust/issues/148581
+        "limit": 2,
+    },
+]
+
+
 def set_retry_on_agent_lost(pipeline: Any) -> None:
     for step in steps(pipeline):
         if "trigger" in step or "wait" in step or "group" in step or "block" in step:
             continue
-        retry = step.setdefault("retry", {})
-        if "automatic" in retry:
+        automatic = step.setdefault("retry", {}).setdefault("automatic", [])
+        # A step retrying on every exit status already covers these.
+        if any(rule.get("exit_status") == "*" for rule in automatic):
             continue
-        retry.setdefault("automatic", []).extend(
-            [
-                {
-                    "exit_status": -1,
-                    "signal_reason": "none",
-                    "limit": 2,
-                },
-                {
-                    "signal_reason": "agent_stop",  # Stopped by OS
-                    "limit": 2,
-                },
-                {
-                    "exit_status": 128,  # Temporary Github/GHCR/DockerHub connection issue
-                    "limit": 2,
-                },
-                {
-                    "exit_status": 199,  # Rust ICE https://github.com/rust-lang/rust/issues/148581
-                    "limit": 2,
-                },
-            ]
+        # Merge rather than skip a step that declares its own rules: skipping
+        # lets a narrow override such as `exit_status: 1` drop every shared rule
+        # and hard-fail the step on the infrastructure classes they exist for.
+        # Nothing surfaces that, and the mzcompose plugin goes out of its way to
+        # propagate 128 and 199 so these rules can match.
+        declared = {(r.get("exit_status"), r.get("signal_reason")) for r in automatic}
+        automatic.extend(
+            dict(rule)
+            for rule in SHARED_AUTOMATIC_RETRIES
+            if (rule.get("exit_status"), rule.get("signal_reason")) not in declared
         )
 
 


### PR DESCRIPTION
`set_retry_on_agent_lost` gives every step four automatic retries for failures that belong to the infrastructure rather than the step: a lost agent, an agent stopped by the OS, exit 128 for a registry or GHCR hiccup, and exit 199 for a Rust ICE. It skipped any step that declared `retry.automatic` of its own:

```python
retry = step.setdefault("retry", {})
if "automatic" in retry:
    continue
```

So a step asking for one extra rule lost all four rather than gaining a fifth. Nothing reports that, and the step then hard-fails on precisely the transient classes the shared rules exist for.

The loss is worth more than it looks. `ci/plugins/mzcompose/hooks/command` deliberately propagates 128 and 199 out of a job rather than collapsing them to 1, with a comment saying that overwriting them "turns a self-healing infra failure into a job that stays red until someone retries it by hand", and `mzbuild.py` exits 128 when a required image cannot be pulled. A step that overrode the rules went red on the first failed image pull where every other step retried twice — the MinIO Docker Hub outage fixed in #38802 is exactly that shape.

Merge instead of skip, adding only the rules a step does not already declare, and leave a step that retries on every exit status alone since it covers them already.

### What regains coverage

Applying the old and new function to every checked-in template, thirteen steps were silently missing rules:

| pipeline | steps | was missing |
|---|---|---|
| test | `devel-docker-tags`, `console-sql-test` | all four |
| test | `check-merge-with-target` | agent-lost only, having re-listed the other three by hand |
| nightly | `devel-docker-tags`, `aws-real`, `aws-glue-schema-registry-real`, 4× `k8s-node-recovery-*`, `terraform-aws-upgrade`, `terraform-azure` | all four |
| spec-sheet | `devel-docker-tags` | all four |

After the change every step in every template carries all four, with no duplicated rules. The `ci/deploy` steps retry on `exit_status: "*"` and are left untouched.

Re-listing the shared rules inside a step stays correct and is now redundant rather than required; I left the existing re-listings in place rather than widen the diff.

Found by the post-merge QA review on #38797.

🤖 Generated with [Claude Code](https://claude.com/claude-code)