### PR TITLE
storage: design and spike of event-driven remap bindings (tickless frontiers)

### DIFF
--- a/doc/developer/design/20260912_tickless_frontiers.md
+++ b/doc/developer/design/20260912_tickless_frontiers.md
@@ -22,7 +22,7 @@ The 2024 rollout of reclock-to-latest-upper measured exactly this regression in 
 
 The load side is equally structural.
 Table 1 lists the durable writes one idle tick costs at the defaults, verified against the current tree.
-Tables are already amortized through txn-wal and cost nothing per table, but each source costs two compare-and-set operations and each materialized view one, whether or not any data moved.
+Tables are already amortized through txn-wal and cost nothing per table, but each source export costs one compare-and-set operation and each materialized view one, whether or not any data moved.
 Production fleets run on the order of ten thousand consensus writes per second at a one second tick, and the consensus store is a major infrastructure cost that scales linearly with that rate, so the fleet cannot absorb a ten times faster tick as-is.
 
 | Cost center | Durable writes per idle tick | Where |
@@ -32,7 +32,7 @@ Production fleets run on the order of ten thousand consensus writes per second a
 | txns shard | 1 compare-and-append, 1 compare-and-downgrade-since | `src/txn-wal/src/txn_write.rs`, `src/storage-controller/src/persist_handles.rs` |
 | Table data shards | 0 | `src/storage-client/src/storage_collections.rs` |
 | Each source | 1 for the remap shard, 1 per export data shard | `src/storage/src/source/reclock.rs`, `src/storage/src/render/persist_sink.rs` |
-| Each materialized view | 1 (empty batch) | `src/compute/src/sink/materialized_view.rs` |
+| Each materialized view | 1, gated on the previous append landing | `src/compute/src/sink/materialized_view.rs` |
 | Each introspection collection | 1 | `src/storage-controller/src/collection_mgmt.rs` |
 
 Table 1: Durable writes per idle tick at the default configuration.
@@ -40,32 +40,39 @@ Table 1: Durable writes per idle tick at the default configuration.
 Two facts about the current implementation shape the design space.
 First, sources never consult the timestamp oracle: the binding timestamp is the clusterd wall clock floored to the interval (`src/storage/src/source/probe.rs`), and the oracle is only written by the coordinator's group commit.
 Second, reclock-to-latest-upper is the only reclocking strategy since [#35046], so a binding always maps a probed upstream frontier, never the ingested one, and the remap operator mints from a probe stream rather than from the data frontier (`src/storage/src/source/source_reader_pipeline.rs`).
-The critical path for a fresher binding is therefore acquiring the upstream frontier and committing the binding, not any oracle round trip.
+The critical path for a fresher binding is therefore acquiring an upstream frontier and committing the binding, not any oracle round trip.
+
+A third fact bounds what finer bindings can deliver on their own.
+Strict serializable reads choose the oracle read timestamp, or the collection since if that is later (`src/adapter/src/coord/timestamp_selection.rs`), and the oracle only advances when a group commit applies.
+Finer source bindings are therefore invisible to the default isolation level until the oracle also advances more often.
+Serializable reads choose the freshest available timestamp and benefit from finer bindings with no other change.
 
 ## Success criteria
 
 * End-to-end freshness, measured from upstream commit to the moment a strict serializable read can observe the row, is bounded by the ingestion pipeline latency plus a configurable minimum binding interval, and the design supports that interval down to 100 ms within the consensus budget stated below. Today the bound is the pipeline latency plus one second.
-* Strict serializable read latency on a source that is receiving data does not regress relative to today. In particular, reads must not wait for upper visibility on every request.
-* Upstream probe load per source does not exceed today's: at most one explicit probe per source per maximum binding interval, and no explicit probes while the replication stream itself carries the upstream frontier.
+* Strict serializable read latency is bounded: a read on an environment where nothing has advanced the timeline within one minimum binding interval pays at most one group commit, and a read on a busy environment pays nothing extra. Reads on a source that is receiving data never wait for upper visibility.
+* Serializable reads observe fresher data with no added latency.
+* Upstream probe load per source does not exceed today's: at most one explicit probe per source per maximum binding interval, and no explicit probes are added while data flows.
 * Durable storage stays bounded: the live size of a remap shard depends on the retention window and partition count, not on the binding rate or the age of the source.
 * Restart is deterministic: the remap shard remains the only source of truth for the mapping, and two replicas or two incarnations of a source produce identical reclocked output.
-* Consensus write rate is an explicit, configurable budget with a documented formula, and the default configuration does not increase the fleet-wide write rate.
-* At an unchanged maximum binding interval, idle collections cost no more durable writes than today, and the environment-level keepalive costs nothing while no reads arrive.
+* Consensus write rate is an explicit, configurable budget with a documented formula.
+* At an unchanged maximum binding interval, no collection costs more durable writes while idle than it does today.
 
 ## Out of scope
 
 * Amortizing consensus writes across shards, for example by routing source exports or materialized views through a txn-wal style shared shard. This is the enabler for binding intervals well below 250 ms at fleet scale and gets its own design. This document sizes the budget it would have to meet.
 * Introspection and managed collections. They advance on a hardcoded one second tick in the storage controller, independent of `timestamp_interval`, and are unaffected here.
-* Sinks. A Kafka sink commits one transaction per input frontier step, so a finer input frontier multiplies sink commits. This document requires that sink input frontiers be quantized and leaves the sink-side cadence knob to a follow-up.
-* Bounded staleness and serializable isolation. They do not anchor to source uppers in a way this design changes.
+* Sinks. A Kafka sink commits one transaction and one progress append per input frontier step (`src/storage/src/sink/kafka.rs`), so a finer input frontier multiplies sink commits. Sinks need the same hold-back operator that this document specifies for materialized views, with their own cadence knob, and that is a follow-up.
+* Bounded staleness and serializable isolation, whose timestamp selection this design does not change.
+* User-defined timelines. They are advanced from collection uppers and only when a group commit applies (`src/adapter/src/coord/timeline.rs`), so under this design they keep today's cadence and inherit the binding lead. They are unused in practice and are left as they are.
 * A durable raw transaction log written before reclocking. See Alternatives.
 
 ## Solution proposal
 
 Frontiers advance when work arrives, bounded below by a minimum binding interval and above by a maximum binding interval, and bindings are minted slightly ahead of wall clock by a measured lead so that fresh uppers are visible by the time a read asks for them.
 Timestamps keep millisecond granularity, and frontiers advance in steps whose size is set by load rather than by a ticker.
-Downstream collections quantize their input frontiers so that a finer source frontier does not multiply their own durable writes.
-The timeline advances on demand rather than on a keepalive ticker, so that read timestamps track wall clock without paying for keepalives when nothing is reading.
+Materialized views hold their output frontier back to a grid so that a finer source frontier does not multiply their own durable writes beyond a bounded rate.
+The timeline advances on demand rather than on a keepalive ticker, so that strict serializable read timestamps track wall clock without paying for keepalives when nothing is reading.
 
 ```mermaid
 flowchart LR
@@ -73,16 +80,16 @@ flowchart LR
         U[upstream log]
     end
     subgraph clusterd
-        R[source reader] -->|data, in-stream tip| M[remap operator]
-        T[idle timer X_max] --> M
-        M -->|"binding (tip, t)"| RS[(remap shard)]
+        R[source reader] -->|data frontier| A[arrival probes]
+        T[idle timer X_max] -->|explicit probe| M[remap operator]
+        A --> M
+        M -->|"binding (frontier, t)"| RS[(remap shard)]
         RS --> RC[reclock]
         R --> RC
         RC --> PS[persist sink] --> DS[(data shard)]
     end
     subgraph envd
-        C[coordinator] -->|read wants ts > upper| P[poke, optional]
-        P -.-> M
+        C[coordinator]
     end
     U --> R
     DS -->|upper| C
@@ -90,23 +97,33 @@ flowchart LR
 
 ### Terminology
 
-* `X_min`, the minimum binding interval. No source mints two bindings closer than `X_min` apart. It bounds the consensus write rate of a busy source to two writes per `X_min`.
-* `X_max`, the maximum binding interval. An idle source mints a binding at least every `X_max`. It bounds staleness and explicit upstream probe rate for idle sources and is the freshness floor of `mz_now()` driven semantics such as temporal filters. It is the existing `TIMESTAMP INTERVAL`.
+* `X_min`, the minimum binding interval. No source mints two bindings closer than `X_min` apart, and binding timestamps lie on the `X_min` grid. It bounds the consensus write rate of a busy source.
+* `X_max`, the maximum binding interval. An idle source mints a binding at least every `X_max`, from an explicit probe. It bounds staleness and explicit upstream probe rate for idle sources and is the floor for `mz_now()` driven semantics such as temporal filters. It is the existing `TIMESTAMP INTERVAL`.
 * `H`, the binding lead. A binding minted at wall clock `w` carries timestamp `w + H` rather than `w`. `H` is measured per source, not configured.
-* `Q`, the quantization step of a downstream collection. Its input frontier is only allowed to advance at multiples of `Q`.
+* `CW`, the compaction window of a collection, one second by default (`src/adapter-types/src/compaction.rs`).
+* `Q`, the hold-back step of a materialized view. Its output frontier only advances at multiples of `Q`.
 
 ### Bindings
 
-The remap operator mints a binding whenever one of three triggers fires and at least `X_min` has elapsed since the previous binding.
-The first trigger is an advance of the upstream frontier observed in the replication stream itself, described per source below.
-The second is the idle timer, which fires `X_max` after the previous binding and performs an explicit probe.
-The third is a poke from the controller on behalf of a waiting read, which is optional and discussed under Alternatives.
-The binding timestamp is `max(now_ms + H, previous_binding + 1)`, floored to the `X_min` grid so that independent sources land on the same timestamps and a join of several sources sees one input frontier step per grid point rather than one per source ([database-issues#8885] describes the cost of misalignment).
+The remap operator mints a binding whenever one of two triggers fires.
+The first trigger is an advance of the source's own data frontier, the frontier of what the reader has ingested, delivered to the remap operator as a probe.
+The second is the idle timer, which fires `X_max` after the previous binding and performs an explicit probe of the upstream system exactly as today.
+Both triggers produce a proposal `(frontier, probe_ts)`, and the remap operator must wake on a changed frontier even when the timestamp is unchanged, because two arrivals inside one grid cell carry the same timestamp and today's wake condition compares timestamps only.
+
+The binding timestamp is `max(floor_grid(now_ms + H), previous_binding + 1)`, where `floor_grid` rounds down to the `X_min` grid.
+The floor is applied before the maximum, otherwise it could undo the maximum and produce a timestamp equal to the previous binding, which `mint` rejects without a diagnostic.
+The target upper is derived from the final timestamp, because `mint` asserts that the upper is beyond the binding timestamp.
+Flooring to a shared grid keeps independent sources on the same timestamps, so a join of several sources sees one input frontier step per grid point rather than one per source ([database-issues#8885] describes the cost of misalignment).
 
 The existing `ReclockOperator::mint` contract already enforces what the triggers need.
-It only writes a binding if the upstream frontier is not behind the previously bound frontier and the target upper strictly advances (`src/storage/src/source/reclock.rs`), and it resyncs on a compare-and-append mismatch.
-An arrival-driven proposal whose ingested frontier is still behind the most recently probed upstream tip is rejected by the first condition, so arrival-driven minting only takes effect once ingestion has caught up with the last probe.
-This gives a clean hybrid: while data flows, bindings track the ingested frontier at `X_min` granularity, and at least every `X_max` an explicit probe re-establishes the reclock-to-latest-upper property that a broken upstream connection stalls the source rather than silently advancing it.
+It only writes a binding if the proposed frontier is not behind the previously bound frontier and the target upper strictly advances (`src/storage/src/source/reclock.rs`), and it resyncs on a compare-and-append mismatch.
+An arrival-driven proposal whose ingested frontier is still behind the most recently probed upstream frontier is rejected by the first condition, so arrival-driven minting only takes effect once ingestion has caught up with the last probe.
+This gives a hybrid: while ingestion keeps up, bindings track the ingested frontier at `X_min` granularity, and at least every `X_max` an explicit probe re-establishes the reclock-to-latest-upper property that a broken or lagging upstream connection stalls the source rather than silently advancing it.
+A rejected proposal is silent today and must carry a counter, because under arrival-driven minting a rejection is the normal case while ingestion catches up and a stuck source would otherwise be indistinguishable from a healthy one.
+
+The proposal must be a complete antichain in the source's time domain, which the data frontier is by construction.
+For Kafka the data frontier covers every consumed partition plus the range element for partitions not yet discovered (`src/storage/src/source/kafka.rs`), so it is comparable with the probed frontier.
+A proposal assembled from a subset of partitions would be incomparable with the last probed frontier, and the partial order in the `mint` guard would reject it forever.
 
 Bindings remain monotone in both coordinates by construction, and multiple transactions that arrive within one `X_min` share a timestamp.
 The upstream total order survives as a happens-before relation: transactions with distinct bindings keep their order, transactions with the same binding are simultaneous.
@@ -114,15 +131,16 @@ This is the same guarantee reclocking gives today at one second granularity (`do
 
 ### Upstream frontier acquisition
 
-Bounded upstream load requires that a busy source learns the upstream frontier from the data it already receives, and only probes explicitly when idle.
+Bounded upstream load requires that no explicit probe is added while data flows, and that the idle probe rate stays at `X_max`.
+The arrival trigger uses the reader's data frontier, which every source already maintains, so no source needs a new upstream query.
 
-| Source | In-stream frontier | Explicit probe today | Under this design |
+| Source | Data frontier while data flows | Explicit probe at `X_max` | Notes |
 |---|---|---|---|
-| PostgreSQL | `wal_end` in every `XLogData` and `PrimaryKeepAlive` message, already used for the data frontier (`src/storage/src/source/postgres/replication.rs`) | `pg_current_wal_lsn()` once per tick | Mint from `wal_end`. The existing one second standby status update with the reply flag set requests a keepalive when idle, so the idle probe is free. Drop the separate probe task. |
-| Kafka | High watermark per partition in every fetch response, cached by the client library | List-offsets metadata fetch per tick per partition | Mint from cached watermarks of consumed partitions. Keep the metadata fetch at `X_max` for partition discovery. |
-| MySQL | None. Binlog heartbeats are not wired to the capability (`src/storage/src/source/mysql/replication.rs`) | `@@global.gtid_executed` once per tick | Arrival-driven bindings bound the ingested frontier. Explicit probe stays at `X_max`. |
-| SQL Server | None, the source polls | `fn_cdc_get_max_lsn()` once per tick | Poll cadence is the binding cadence. `X_min` and `X_max` set the poll interval bounds. |
-| Load generator | Synthesized | Synthesized per tick | Unchanged, minting at `X_max`. |
+| PostgreSQL | `commit_lsn + 1` per transaction, and the keepalive `wal_end`, which is the last LSN the walsender processed rather than the WAL end (`src/storage/src/source/postgres/replication.rs` module doc) | `pg_current_wal_lsn()` as today, which also feeds the `offset_known` statistic | The eager pre-snapshot probe stays. On filtered publications and hosts with other write-active databases the data frontier trails the true WAL tip, so the `X_max` probe is what keeps the source reclock-to-latest-upper. |
+| Kafka | Per-partition consumer positions plus the undiscovered-partition range element | Metadata fetch of high watermarks and partition list as today | The metadata fetch is also partition discovery and cannot be dropped. |
+| MySQL | GTID frontier advanced on transaction events | `@@global.gtid_executed` as today | Binlog heartbeats are not wired to the capability and stay that way. |
+| SQL Server | Advances only on poll | `fn_cdc_get_max_lsn()` as today | Poll cadence is the binding cadence. `X_min` and `X_max` bound the poll interval. |
+| Load generator | Generated frontier | Synthesized | Unchanged. |
 
 Table 2: How each source learns the upstream frontier.
 
@@ -130,84 +148,100 @@ Table 2: How each source learns the upstream frontier.
 
 Without a lead, finer bindings make strict serializable reads slower, not faster.
 Today a binding at second `S` covers the interval `[S, S+1)`, and a read whose oracle timestamp falls after the new upper has become visible proceeds immediately, so only reads in the first few hundred milliseconds of each second wait.
-With millisecond bindings and no lead, the visible upper always trails wall clock by the pipeline latency, so every read at an oracle timestamp near wall clock waits for the next binding to propagate.
-The lead `H` restores the property that the visible upper is ahead of wall clock: a binding minted at `w` with timestamp `w + H` becomes visible at roughly `w + L`, where `L` is the pipeline latency, so choosing `H` at or slightly above `L` keeps reads unblocked.
+With grid bindings and no lead, the visible upper always trails wall clock by the pipeline latency `L`, so every read at an oracle timestamp near wall clock waits for the next binding to propagate.
+The lead restores the property that the visible upper is ahead of wall clock.
 
-Each source measures `L` locally as an exponentially weighted average of the time from mint to compare-and-append acknowledgement, plus a fixed allowance for controller propagation, and sets `H` from it, clamped to `[0, X_max]`.
-The label a row receives is its upstream commit time plus at most `H + X_min`, which stays inside today's envelope of commit time plus one second as long as `H + X_min <= X_max`.
+The requirement is that the newest visible binding covers the read timestamp.
+At wall clock `now` the newest visible binding was minted no later than `now - L`, and it was minted at most `X_min` after its predecessor, so its timestamp is at least `now - L - X_min + H`.
+The lead must therefore satisfy `H > L + X_min`, and each source sets `H` to an exponentially weighted average of its observed `L`, from mint to compare-and-append acknowledgement plus a fixed allowance for controller propagation, plus `X_min` and a margin.
+
+The lead is bounded above by the compaction window.
+The since of a collection is `floor(upper - CW)` at one second granularity (`src/storage-types/src/read_policy.rs`), and a strict serializable read with oracle timestamp within `X_min` of wall clock needs `since <= now - X_min`, which holds whenever `H <= CW - X_min`.
+The clamp uses the smallest compaction window across the source's exports and is recomputed when `RETAIN HISTORY` changes.
+Together the two bounds require `L + 2 * X_min <= min(CW, X_max)`, which at the defaults of `CW = X_max = 1 s`, `X_min = 250 ms`, and a measured `L` around 300 ms leaves 200 ms of margin, and this inequality is the real upper bound on `X_min` at a given compaction window.
+
+The label a row receives is its upstream commit time plus at most `H + X_min`, which stays inside today's envelope of commit time plus one second under the same inequality.
+Serializable reads, which pick the freshest available timestamp, will see `mz_now()` up to `H` ahead of wall clock, exactly as they see it up to one second ahead today.
 The lead is a labeling choice and does not change what data exists at any upstream position, so determinism on restart is unaffected.
-The lead does interact with the wall-clock lag metric, which compares uppers to wall clock and would read the lead as negative lag. See Open questions.
+The lead does interact with the wall-clock lag metric, which saturates at zero when an upper is ahead of wall clock (`src/cluster-client/src/lib.rs`) and would under-report lag by `H`. See Open questions.
 
 ### Timeline advancement on demand
 
 The coordinator's keepalive group commit exists so that the oracle read timestamp tracks wall clock and tables remain readable at it (`src/adapter/src/coord/appends.rs`).
-Under this design the keepalive fires on demand instead of on a ticker: when a strict serializable read finds the oracle read timestamp more than `X_min` behind wall clock, it triggers one keepalive commit and waits for it, coalescing with other waiting reads.
+Under this design the keepalive fires on demand: when a strict serializable read finds the oracle read timestamp more than `X_min` behind wall clock, it triggers one keepalive commit and waits for it, coalescing with other waiting reads.
 The precedent is the nudge in `src/adapter/src/frontend_read_then_write.rs`, which asks for a commit instead of waiting a full interval.
-An idle timer at `X_max` keeps `mz_now()` moving for temporal filters and refresh schedules when no reads arrive.
-A sparse read therefore pays one group commit of latency in exchange for a read timestamp within `X_min` of wall clock, where today it reads for free at a timestamp up to one second stale.
-The per-environment cost is unchanged under read load and drops to zero when idle, and all of the correctness argument goes through the oracle exactly as today, so the invariants in `doc/developer/guide-adapter.md` hold.
+An idle timer at `X_max` keeps `mz_now()` moving for temporal filters and refresh schedules when no reads arrive, at today's cost.
+A sparse read pays one group commit of latency in exchange for a read timestamp within `X_min` of wall clock, where today it reads for free at a timestamp up to one second stale, and a busy environment pays nothing extra because a recent keepalive already exists.
 
-Read timestamp selection itself does not change.
-Later timestamps are always safe within a read's real-time bounds, and every advancement of the oracle happens through `apply_write`, so the distributed and monotonicity requirements of the adapter guide are preserved.
-This design does not pick read timestamps from source uppers, which the 2023 latency-versus-freshness exploration rejected because a source with a skewed clock could drag the oracle forward.
+A read-triggered keepalive at a rate of at most one per `X_min` stays clear of the committer's throttle, which only sleeps while the allocated write timestamp is ahead of wall clock, and far below the runaway bound on write timestamps.
+Read timestamp selection itself does not change for the wall-clock timeline: later timestamps are always safe within a read's real-time bounds, and every advancement of the oracle happens through `apply_write`, so the distributed and monotonicity requirements of `doc/developer/guide-adapter.md` are preserved.
+This design does not pick wall-clock timeline read timestamps from source uppers, which the 2023 latency-versus-freshness exploration rejected because a source with a skewed clock could drag the oracle forward.
 
-### Frontier quantization downstream
+### Materialized view hold-back
 
-A materialized view appends one batch per input frontier step, whether or not data moved, and a Kafka sink commits one transaction per step.
-Finer source frontiers therefore multiply downstream durable writes unless downstream collections quantize.
-A quantizer sits at the input of every dataflow that feeds a durable sink and only passes the input frontier at multiples of `Q`, leaving data timestamps untouched.
-The existing temporal bucketing operator in compute (`compute_temporal_bucketing_summary`) shows that coarsening frontiers without changing data timestamps is already an established pattern in the rendering layer.
+A materialized view mints a new batch description only after the previous append has landed (`src/compute/src/sink/materialized_view.rs`), so it is already self-clocked at one append per persist round trip.
+Finer input frontiers raise its append rate from one per tick to one per round trip, which at typical round trips is several times today's rate.
+A hold-back operator on the desired frontier, immediately before batch description minting, downgrades the sink's output capability only at multiples of `Q` and leaves data timestamps untouched.
+Holding a capability back is always legal because the capability stays behind the data, which distinguishes this from `apply_refresh` in `src/compute/src/sink/refresh.rs`, where rounding a frontier up forces data timestamps up as well.
+The empty frontier bypasses the hold-back so that a closing dataflow still closes its shard.
 
-`Q` defaults to `X_min` for materialized views, which preserves alignment without adding delay, and to `X_max` for sinks, which preserves today's sink cadence.
-Both are per-collection knobs so that a specific materialized view can trade consensus writes for freshness.
-The quantizer is also the natural place for an adaptive policy later: a sink that observes slow commits can widen `Q` on its own.
+`Q` defaults to `X_min`, which makes materialized view append rates equal to source append rates and keeps materialized view uppers on the same grid as their inputs.
+A materialized view that keeps up with its inputs then has an upper at or above `floor_grid(now + H)`, which is ahead of wall clock whenever `H >= X_min`, so strict serializable reads on it do not wait either.
+A materialized view that does not keep up is late by its own processing time, exactly as today.
+`Q` is a per-collection knob so that a specific materialized view can trade consensus writes for freshness in either direction, and its effects on the hydration signal and the wall-clock lag histogram are the same as those of a slower input.
 
 ### Storage growth
 
 A binding adds one row per changed partition to the remap shard, encoded as an increment so that rows consolidate (`doc/developer/design/20220411_reclocking_implementation.md`).
-Compaction consolidates all rows below the shard's since into one row per partition, and the since follows the data shard's since, which lags the upper by the compaction window.
-The live row count of a remap shard is therefore the binding rate times the compaction window plus one row per partition, and is independent of source age.
+The remap shard since is the meet of the ingestion's forwarded read hold at `floor(data_upper - CW)`, the controller's one step safety hold behind the data upper (`src/storage-controller/src/lib.rs`), and the progress collection's own read policy, and with `CW` at least one second the first dominates.
+Compaction consolidates all rows below the since into one row per partition, so the live row count is the binding rate times `CW` plus one row per partition, and is independent of source age.
 At the proposed defaults that is a handful of rows per source.
 
-Persist state grows with the number of compare-and-set operations only transiently.
-Each successful append adds a batch that the spine merges, a rollup is written every 128 sequence numbers, and garbage collection truncates consensus every 32, so state size is bounded by spine invariants and blob count by the merge schedule, both proportional to write rate but not to age.
-The data shard sees the same pattern because empty batches do not add parts.
-Nothing new is stored: the design changes when existing writes happen, not what is written.
+Persist state grows with the number of appends only transiently, but each append has a fixed cost.
+An empty append adds no parts and its empty spine batch fuses away, yet it still costs a sequence number, a state diff, a consensus compare-and-set, a clone of the shard state, and a pub-sub fan-out, and the state clone is proportional to the number of batches in the spine.
+Rollups are written every 128 sequence numbers and consensus is truncated at rollup boundaries, so state and blob counts are bounded by the merge schedule and proportional to write rate, not to age.
+In the storage persist sink one batch is finished per distinct data timestamp inside a description (`src/storage/src/render/persist_sink.rs`), so grid bindings at `X_min` produce `X_max / X_min` times as many batch objects and blob parts as today regardless of any hold-back, while ready descriptions are already coalesced into one compare-and-set by default.
+Nothing new is stored, but the per-append fixed cost is why `X_min` and not only the compare-and-set count is the budget unit.
 
 ### Determinism on restart
 
-The remap shard is written before any data is reclocked, and the reclock operator holds its capability until the reader has read through the binding (`src/timely-util/src/reclock.rs`), so the data shard upper never exceeds the remap shard upper.
+The remap shard is written before any data is reclocked: the remap operator downgrades its capability only after the compare-and-append lands (`src/storage/src/source/source_reader_pipeline.rs`), and the reclock operator's output frontier is bounded by the remap input frontier (`src/timely-util/src/reclock.rs`), so the data shard upper never exceeds the remap shard upper.
 On restart the source reads the data shard upper, maps it back to an upstream position through the remap shard (`reclock_committed_upper` in `src/storage/src/source/source_reader_pipeline.rs`), resumes upstream from there, and re-ingested data receives the bindings already on record.
 Arrival-driven minting and the lead do not touch this argument, because both only decide which timestamp a new binding proposes, and proposals become truth only through the compare-and-append on the remap shard.
 Two replicas racing to mint resolve through the same compare-and-append, the loser resyncs to the winner's bindings, and both reclock identically, which the existing concurrency test in `src/storage/src/source/reclock.rs` exercises.
+
+During a zero-downtime upgrade the read-only generation cannot mint bindings or write the oracle, and its remap handle polls the shard on a hardcoded one second loop (`src/storage/src/source/reclock/compat.rs`).
+The read-only generation therefore observes the writing generation's cadence and adds up to one second of its own, exactly as today.
+Nothing in this design changes that, and the cutover freshness check should keep tolerating it.
 
 ### Consensus budget
 
 The durable write rate of the system under this design is
 
-* per busy source: `2 / X_min`
-* per idle source: `2 / X_max`
-* per materialized view: `1 / Q`
-* per environment: `3 / X_min` under read load for oracle, catalog, and txns shard writes, zero when idle
+* per busy source with `N` exports: `(1 + N) / X_min`
+* per idle source with `N` exports: `(1 + N) / X_max`, unchanged from today
+* per materialized view: `1 / max(Q, persist round trip)`
+* per environment: `3 / X_min` under read load for oracle, catalog, and txns shard writes, and `3 / X_max` when idle, unchanged from today
 
-At `X_min = 250 ms` and `X_max = 1 s`, an idle shard writes exactly what it writes today and a busy shard writes four times more, so the fleet-wide rate grows with the fraction of busy shards.
-Idle shards only get cheaper when `X_max` is raised, which trades idle staleness and a slower `mz_now()` floor for consensus writes, and is a per-environment choice.
-`X_min` defaults to 250 ms and is configurable per environment, so a fleet with many busy shards can raise it back to `X_max` to reproduce today's write rate exactly.
+At `X_min = 250 ms` and `X_max = 1 s`, an idle shard writes exactly what it writes today and a busy shard writes four times more, so the fleet-wide rate grows with the fraction of busy exports.
+A multi-table PostgreSQL source with forty exports is forty-one busy shards, which is the common shape and the reason the budget is per export.
+Idle shards only get cheaper when `X_max` is raised, which trades idle staleness and a slower `mz_now()` floor for consensus writes, and is a per-environment choice that also requires raising `max_timestamp_interval`.
+`X_min` defaults to 250 ms and is configurable per environment, so a fleet with many busy exports can raise it back to `X_max` to reproduce today's write rate exactly.
 The self-adjusting behavior the problem statement asks for comes from two places: while an append is in flight, arrivals accumulate into the next binding, so steps grow with load, and `X_min` caps the rate when arrivals trickle.
 Amortizing appends across shards is what makes `X_min` well below 250 ms affordable at fleet scale, and is out of scope here.
 
 ### Configuration and rollout
 
-* `X_max` is the existing `TIMESTAMP INTERVAL` source option and `default_timestamp_interval`, with unchanged meaning.
+* `X_max` is the existing `TIMESTAMP INTERVAL` source option and `default_timestamp_interval`, with unchanged meaning. It is clamped to `[min_timestamp_interval, max_timestamp_interval]`, both one second by default, so raising it is an operator action.
 * `X_min` is a new dyncfg `storage_min_binding_interval`, defaulting to 250 ms. Setting it to `X_max` reproduces today's cadence.
-* Event-driven minting and the lead are behind a feature flag that defaults off in production and on in CI, wired through `system_parameter_default` so that sqllogictest, testdrive, and platform checks exercise the new path.
-* The lead `H` is observable per source through source statistics.
-* `Q` is a per-collection option with the defaults above.
+* Event-driven minting, the lead, and the demand-driven keepalive are behind a feature flag that defaults off in production and on in CI, wired through `system_parameter_default` so that sqllogictest, testdrive, and platform checks exercise the new path.
+* The lead `H` and the rejected-proposal count are new per-source statistics and need a source statistics field and a catalog relation change.
+* `Q` is a per-collection option with the default above.
 
 ## Minimal viable prototype
 
-The prototype covers the PostgreSQL source and the load generator, because PostgreSQL already carries the upstream frontier in-stream and the load generator gives a controlled arrival rate.
-It implements arrival-driven minting with `X_min` and `X_max`, the measured lead, and the demand-driven keepalive, and leaves quantization at its default of `Q = X_min`.
+The prototype covers the PostgreSQL source and the load generator, because PostgreSQL exercises the hybrid of arrival-driven and probe-driven bindings and the load generator gives a controlled arrival rate.
+It implements arrival-driven minting with `X_min` and `X_max`, a lead from a fixed configuration value standing in for the measurement, and a faster keepalive standing in for the demand-driven one, and leaves the materialized view hold-back for after the measurement.
 The measurements are end-to-end freshness as the difference between upstream commit time and first visibility in a strict serializable read, strict serializable read latency distribution, compare-and-set rate per shard from persist metrics, and explicit probe count against the upstream database.
 Success is a freshness median below `X_min` plus pipeline latency at unchanged read latency and unchanged probe count, with the consensus rate matching the budget formula.
 
@@ -226,6 +260,13 @@ This keeps labels at upstream commit time but adds a controller-to-cluster proto
 The lead achieves unblocked reads without a protocol.
 The poke remains useful as a targeted mechanism for reads against sources that are idle for longer than `X_max` and could be added later.
 
+### Mint from upstream metadata carried in the stream
+
+An earlier draft proposed minting PostgreSQL bindings from the `wal_end` field of every replication message and Kafka bindings from cached high watermarks.
+The PostgreSQL keepalive `wal_end` is the last LSN the walsender processed, not the WAL end, so it is a data frontier rather than an upstream tip, and the `XLogData` field is not consulted at all.
+Cached Kafka watermarks cover only consumed partitions and produce a frontier incomparable with the probed one.
+Using the data frontier directly gives the same arrival signal for every source with no per-source protocol knowledge.
+
 ### Durable raw log, then deterministic reclocking
 
 The problem statement proposes writing the ingested transaction log durably first, reclocking deterministically in a second step, and garbage collecting reclocked input.
@@ -243,7 +284,7 @@ Frontiers are promises and promises must be durable, so this is rejected.
 
 The 2023 exploration proposed minting source timestamps a fixed one or two seconds ahead and widening the compaction window to match.
 A fixed lead either exceeds the pipeline latency, adding staleness for nothing, or falls short of it under load, reintroducing read waits.
-The measured lead in this design is the same idea with the constant replaced by the quantity it was approximating.
+The measured lead in this design is the same idea with the constant replaced by the quantity it was approximating, and with the compaction window bound made explicit.
 
 ### Amortize consensus writes first
 
@@ -255,7 +296,6 @@ It is complementary and is the natural next design once the budget formula above
 
 * How should the wall-clock lag metric account for the lead? Uppers ahead of wall clock read as zero lag. Each writer can announce its lead through source statistics so the controller subtracts it, or the metric can be anchored on the mint wall clock rather than the binding timestamp. Deferred until the prototype shows how large `H` is in practice.
 * Can `X_min` adapt to observed consensus latency at the controller level, so that a struggling consensus store widens binding intervals across all sources instead of relying on operator tuning?
-* For MySQL, should the explicit probe cadence while data flows be `X_max`, which makes the source reclock-to-latest-upper only once per `X_max`, or should the binlog heartbeat be wired into the capability to provide an in-stream frontier?
-* Does the Kafka client library expose the cached high watermark to the source without a network round trip in the way the source needs, including after a rebalance?
+* Should the demand-driven keepalive distinguish reads that touch no table, which only need the oracle advanced and not a txns shard append?
 * Which tests encode the one second tick as an assumption? The rollout flag being on in CI will surface them, and they need review rather than blanket relaxation.
 * Should `TIMESTAMP INTERVAL` eventually mean `X_min` rather than `X_max`, since users who set it are asking for freshness rather than for an idle cadence? Its one second default reads as an idle cadence today, so it stays `X_max` for now and the question is deferred until `X_min` has a user-facing surface.

--- a/doc/developer/design/20260912_tickless_frontiers.md
+++ b/doc/developer/design/20260912_tickless_frontiers.md
@@ -236,7 +236,7 @@ Amortizing appends across shards is what makes `X_min` well below 250 ms afforda
 
 ### Configuration and rollout
 
-* `X_max` is the existing `TIMESTAMP INTERVAL` source option and `default_timestamp_interval`, with unchanged meaning. Only an explicit `TIMESTAMP INTERVAL` is clamped to `[min_timestamp_interval, max_timestamp_interval]`, both one second by default. `default_timestamp_interval` is applied unclamped to sources that omit the option and to the coordinator keepalive.
+* `X_max` is the existing `TIMESTAMP INTERVAL` source option and `default_timestamp_interval`. Its meaning narrows under the flag: it bounds the explicit probe cadence, but frontiers no longer lie on its grid, they lie on the `X_min` grid, so a test that asserts `write_frontier % interval = 1` holds only with the flag off. Only an explicit `TIMESTAMP INTERVAL` is clamped to `[min_timestamp_interval, max_timestamp_interval]`, both one second by default. `default_timestamp_interval` is applied unclamped to sources that omit the option and to the coordinator keepalive.
 * `X_min` is a new dyncfg `storage_min_binding_interval`, defaulting to 250 ms. Setting it to `X_max` reproduces today's cadence.
 * Event-driven minting, the lead, and the demand-driven keepalive are behind a feature flag that defaults off in production and on in CI, wired through `system_parameter_default` so that sqllogictest, testdrive, and platform checks exercise the new path.
 * The lead `H` and the rejected-proposal count are new per-source statistics and need a source statistics field and a catalog relation change.

--- a/doc/developer/design/20260912_tickless_frontiers.md
+++ b/doc/developer/design/20260912_tickless_frontiers.md
@@ -110,8 +110,9 @@ The first trigger is an advance of the source's own data frontier, the frontier 
 The second is the idle timer, which fires `X_max` after the previous binding and performs an explicit probe of the upstream system exactly as today.
 Both triggers produce a proposal `(frontier, probe_ts)`, and the remap operator must wake on a changed frontier even when the timestamp is unchanged, because two arrivals inside one grid cell carry the same timestamp and today's wake condition compares timestamps only.
 
-The binding timestamp is `max(floor_grid(now_ms + H), previous_binding + 1)`, where `floor_grid` rounds down to the `X_min` grid.
-The floor is applied before the maximum, otherwise it could undo the maximum and produce a timestamp equal to the previous binding, which `mint` rejects without a diagnostic.
+The binding timestamp is `floor_grid(now_ms + H)`, where `floor_grid` rounds down to the `X_min` grid.
+A proposal whose floored timestamp is not at or beyond the current remap upper is skipped without minting, and the operator waits for the next probe.
+Taking the maximum with the previous binding instead would mint off the grid at arrival rate whenever arrivals are faster than the grid, which defeats the rate bound, and the pending arrival probe fires in the next grid cell anyway.
 The target upper is derived from the final timestamp, because `mint` asserts that the upper is beyond the binding timestamp.
 Flooring to a shared grid keeps independent sources on the same timestamps, so a join of several sources sees one input frontier step per grid point rather than one per source ([database-issues#8885] describes the cost of misalignment).
 
@@ -245,6 +246,32 @@ It implements arrival-driven minting with `X_min` and `X_max`, a lead from a fix
 The measurements are end-to-end freshness as the difference between upstream commit time and first visibility in a strict serializable read, strict serializable read latency distribution, compare-and-set rate per shard from persist metrics, and explicit probe count against the upstream database.
 Success is a freshness median below `X_min` plus pipeline latency at unchanged read latency and unchanged probe count, with the consensus rate matching the budget formula.
 
+### Prototype results
+
+The prototype is on this branch behind `storage_event_driven_bindings`, with `test/tickless-spike/spike.py` as the harness.
+It runs a local PostgreSQL source at 20 inserts per second against a local `environmentd` with the optimized profile, one strict serializable reader polling `max(ts)` every 50 ms, and one `SUBSCRIBE` on the progress subsource counting distinct binding timestamps.
+Staleness is wall clock at read completion minus the row's upstream commit time, so it includes the read's own latency, and the keepalive is emulated by lowering `default_timestamp_interval` after source creation.
+The lead is a fixed value rather than a measurement.
+
+| Mode | Staleness p50 ms | Staleness p95 ms | Read p50 ms | Read p95 ms | Bindings/s |
+|---|---|---|---|---|---|
+| Baseline, 1 s keepalive | 1035 | 1063 | 950 | 954 | 1.03 |
+| Baseline, 250 ms keepalive | 1151 | 1256 | 18 | 751 | 1.03 |
+| Event-driven, lead 0, 250 ms keepalive | 299 | 504 | 22 | 254 | 3.92 |
+| Event-driven, lead 400 ms, 250 ms keepalive | 581 | 727 | 18 | 22 | 4.06 |
+
+Table 3: One 30 second run per mode, single machine, 20 inserts per second.
+
+Four things follow from the numbers.
+The binding rate lands on the grid as designed, four per second against one, and the log shows no rejected proposals, no panics, and no persist errors.
+Event-driven bindings without a lead cut median staleness from about one second to 300 ms, which is the pipeline latency plus a fraction of the grid, and the read tail of 254 ms is the wait for the next binding that the lead section predicts.
+The lead removes that tail, 254 ms to 22 ms at p95, and pays for it in staleness, 299 ms to 581 ms at the median, so the lead is a read latency instrument and not a freshness instrument, and the sum of read latency and staleness is about the same in both event-driven modes.
+The baseline with a one second keepalive shows a 950 ms median read latency, which is the since rounding effect the Binding lead section describes: the source since is floored to the second, the oracle read timestamp lags by up to a second, and every read is pushed to the since and waits for the next keepalive.
+
+A quiet run at one insert per five seconds counted 0.3 bindings per second in both modes, below the expected one per second from the `X_max` probe.
+The counter only sees bindings that move the upstream frontier, because a binding that repeats the same frontier at a new timestamp consolidates to nothing in the progress collection, so the harness measures data-bearing bindings and cannot see idle ones.
+Idle binding rate needs a persist-level counter, which is the same instrument the rejected-proposal count needs.
+
 ## Alternatives
 
 ### Lower the timestamp interval globally
@@ -295,6 +322,7 @@ It is complementary and is the natural next design once the budget formula above
 ## Open questions
 
 * How should the wall-clock lag metric account for the lead? Uppers ahead of wall clock read as zero lag. Each writer can announce its lead through source statistics so the controller subtracts it, or the metric can be anchored on the mint wall clock rather than the binding timestamp. Deferred until the prototype shows how large `H` is in practice.
+* Should the lead default to zero? The prototype shows the lead trading staleness for read tail latency one for one. If freshness is the goal, a zero lead with the read tail bounded by `X_min` may be the better default, with the lead reserved for environments that care about read latency.
 * Can `X_min` adapt to observed consensus latency at the controller level, so that a struggling consensus store widens binding intervals across all sources instead of relying on operator tuning?
 * Should the demand-driven keepalive distinguish reads that touch no table, which only need the oracle advanced and not a txns shard append?
 * Which tests encode the one second tick as an assumption? The rollout flag being on in CI will surface them, and they need review rather than blanket relaxation.

--- a/doc/developer/design/20260912_tickless_frontiers.md
+++ b/doc/developer/design/20260912_tickless_frontiers.md
@@ -272,6 +272,10 @@ Event-driven bindings without a lead cut median staleness from about one second 
 The lead removes that tail, 254 ms to 22 ms at p95, and pays for it in staleness, 299 ms to 581 ms at the median, so the lead is a read latency instrument and not a freshness instrument, and the sum of read latency and staleness is about the same in both event-driven modes.
 The baseline with a one second keepalive shows a 950 ms median read latency, which is the since rounding effect the Binding lead section describes: the source since is floored to the second, the oracle read timestamp lags by up to a second, and every read is pushed to the since and waits for the next keepalive.
 
+The nightly workload replay, a sandbox environment with PostgreSQL and MySQL CDC sources, Kafka, load generators, and a continuous query mix, compared the flag on against the merge base on one run each.
+Query latency fell across the distribution, p95 from 695 ms to 242 ms and average from 264 ms to 63 ms, while average CPU rose from 100 to 137 percent of a core, a 36 percent increase that the benchmark flags as a regression, and memory was flat.
+Every source in that workload receives data continuously, so this is the all-busy end of the consensus budget: four times the frontier steps through every downstream dataflow and persist sink, paid in CPU, bought with a threefold improvement in tail query latency.
+
 A quiet run at one insert per five seconds counted 0.3 bindings per second in both modes, below the expected one per second from the `X_max` probe.
 The counter only sees bindings that move the upstream frontier, because a binding that repeats the same frontier at a new timestamp consolidates to nothing in the progress collection, so the harness measures data-bearing bindings and cannot see idle ones.
 Idle binding rate needs a persist-level counter, which is the same instrument the rejected-proposal count needs.

--- a/doc/developer/design/20260912_tickless_frontiers.md
+++ b/doc/developer/design/20260912_tickless_frontiers.md
@@ -109,6 +109,8 @@ The remap operator mints a binding whenever one of two triggers fires.
 The first trigger is an advance of the source's own data frontier, the frontier of what the reader has ingested, delivered to the remap operator as a probe.
 The second is the idle timer, which fires `X_max` after the previous binding and performs an explicit probe of the upstream system exactly as today.
 Both triggers produce a proposal `(frontier, probe_ts)`, and the remap operator must wake on a changed frontier even when the timestamp is unchanged, because two arrivals inside one grid cell carry the same timestamp and today's wake condition compares timestamps only.
+Arrival proposals are only made at or beyond the most advanced frontier an explicit probe has reported, so the first binding of a source is always minted from an explicit probe.
+Without that gate a Kafka source, whose data frontier moves from the first fetch because it has no separate snapshot phase, minted its snapshot binding from a partial snapshot, and a sink created right after the source observed intermediate states instead of one accumulated record.
 
 The binding timestamp is `floor_grid(probe_ts + H)`, where `floor_grid` rounds down to the `X_min` grid and `probe_ts` is the wall clock at which the proposal was made, already on the `X_max` grid for explicit probes.
 A proposal whose floored timestamp is not at or beyond the current remap upper is deferred to the start of the next grid cell rather than dropped, and a probe arriving in the meantime replaces the held one only if its frontier is at least as advanced, so the explicit `X_max` probe is not lost to an arrival probe that used the same cell.

--- a/doc/developer/design/20260912_tickless_frontiers.md
+++ b/doc/developer/design/20260912_tickless_frontiers.md
@@ -110,17 +110,20 @@ The first trigger is an advance of the source's own data frontier, the frontier 
 The second is the idle timer, which fires `X_max` after the previous binding and performs an explicit probe of the upstream system exactly as today.
 Both triggers produce a proposal `(frontier, probe_ts)`, and the remap operator must wake on a changed frontier even when the timestamp is unchanged, because two arrivals inside one grid cell carry the same timestamp and today's wake condition compares timestamps only.
 
-The binding timestamp is `floor_grid(now_ms + H)`, where `floor_grid` rounds down to the `X_min` grid.
-A proposal whose floored timestamp is not at or beyond the current remap upper is skipped without minting, and the operator waits for the next probe.
-Taking the maximum with the previous binding instead would mint off the grid at arrival rate whenever arrivals are faster than the grid, which defeats the rate bound, and the pending arrival probe fires in the next grid cell anyway.
+The binding timestamp is `floor_grid(probe_ts + H)`, where `floor_grid` rounds down to the `X_min` grid and `probe_ts` is the wall clock at which the proposal was made, already on the `X_max` grid for explicit probes.
+A proposal whose floored timestamp is not at or beyond the current remap upper is deferred to the start of the next grid cell rather than dropped, so the explicit `X_max` probe is never lost to an arrival probe that used the same cell.
+Taking the maximum with the previous binding instead would mint off the grid at arrival rate whenever arrivals are faster than the grid, which defeats the rate bound.
 The target upper is derived from the final timestamp, because `mint` asserts that the upper is beyond the binding timestamp.
+Deferred proposals and proposals that `mint` rejects because their frontier is behind the recorded one each carry a per-source counter, because under arrival-driven minting both are normal and a stuck source would otherwise be indistinguishable from a healthy one.
 Flooring to a shared grid keeps independent sources on the same timestamps, so a join of several sources sees one input frontier step per grid point rather than one per source ([database-issues#8885] describes the cost of misalignment).
 
 The existing `ReclockOperator::mint` contract already enforces what the triggers need.
 It only writes a binding if the proposed frontier is not behind the previously bound frontier and the target upper strictly advances (`src/storage/src/source/reclock.rs`), and it resyncs on a compare-and-append mismatch.
 An arrival-driven proposal whose ingested frontier is still behind the most recently probed upstream frontier is rejected by the first condition, so arrival-driven minting only takes effect once ingestion has caught up with the last probe.
 This gives a hybrid: while ingestion keeps up, bindings track the ingested frontier at `X_min` granularity, and at least every `X_max` an explicit probe re-establishes the reclock-to-latest-upper property that a broken or lagging upstream connection stalls the source rather than silently advancing it.
-A rejected proposal is silent today and must carry a counter, because under arrival-driven minting a rejection is the normal case while ingestion catches up and a stuck source would otherwise be indistinguishable from a healthy one.
+The flip side is that arrival-driven minting is inert for as long as ingestion trails the last probed upstream frontier, because every arrival proposal is behind it.
+A Kafka consumer under load is by construction behind the high watermark, and a PostgreSQL source on a filtered publication or on a host with other write-active databases trails the WAL tip, so in exactly the busy cases where freshness matters most the source falls back to the `X_max` cadence.
+This is the main open risk of the design and the prototype did not measure it. See Open questions.
 
 The proposal must be a complete antichain in the source's time domain, which the data frontier is by construction.
 For Kafka the data frontier covers every consumed partition plus the range element for partitions not yet discovered (`src/storage/src/source/kafka.rs`), so it is comparable with the probed frontier.
@@ -233,7 +236,7 @@ Amortizing appends across shards is what makes `X_min` well below 250 ms afforda
 
 ### Configuration and rollout
 
-* `X_max` is the existing `TIMESTAMP INTERVAL` source option and `default_timestamp_interval`, with unchanged meaning. It is clamped to `[min_timestamp_interval, max_timestamp_interval]`, both one second by default, so raising it is an operator action.
+* `X_max` is the existing `TIMESTAMP INTERVAL` source option and `default_timestamp_interval`, with unchanged meaning. Only an explicit `TIMESTAMP INTERVAL` is clamped to `[min_timestamp_interval, max_timestamp_interval]`, both one second by default. `default_timestamp_interval` is applied unclamped to sources that omit the option and to the coordinator keepalive.
 * `X_min` is a new dyncfg `storage_min_binding_interval`, defaulting to 250 ms. Setting it to `X_max` reproduces today's cadence.
 * Event-driven minting, the lead, and the demand-driven keepalive are behind a feature flag that defaults off in production and on in CI, wired through `system_parameter_default` so that sqllogictest, testdrive, and platform checks exercise the new path.
 * The lead `H` and the rejected-proposal count are new per-source statistics and need a source statistics field and a catalog relation change.
@@ -253,17 +256,18 @@ It runs a local PostgreSQL source at 20 inserts per second against a local `envi
 Staleness is wall clock at read completion minus the row's upstream commit time, so it includes the read's own latency, and the keepalive is emulated by lowering `default_timestamp_interval` after source creation.
 The lead is a fixed value rather than a measurement.
 
-| Mode | Staleness p50 ms | Staleness p95 ms | Read p50 ms | Read p95 ms | Bindings/s |
-|---|---|---|---|---|---|
-| Baseline, 1 s keepalive | 1035 | 1063 | 950 | 954 | 1.03 |
-| Baseline, 250 ms keepalive | 1151 | 1256 | 18 | 751 | 1.03 |
-| Event-driven, lead 0, 250 ms keepalive | 299 | 504 | 22 | 254 | 3.92 |
-| Event-driven, lead 400 ms, 250 ms keepalive | 581 | 727 | 18 | 22 | 4.06 |
+| Mode | Staleness p50 ms | Staleness p95 ms | Read p50 ms | Read p95 ms | Bindings/s | Reads |
+|---|---|---|---|---|---|---|
+| Baseline, 1 s keepalive | 1035 | 1063 | 950 | 954 | 1.03 | 31 |
+| Baseline, 250 ms keepalive | 1151 | 1256 | 18 | 751 | 1.03 | 121 |
+| Event-driven, lead 0, 250 ms keepalive | 299 | 504 | 22 | 254 | 3.92 | 210 |
+| Event-driven, lead 400 ms, 250 ms keepalive | 581 | 727 | 18 | 22 | 4.06 | 437 |
 
-Table 3: One 30 second run per mode, single machine, 20 inserts per second.
+Table 3: One 30 second run per mode, single machine, 20 inserts per second. The reader polls as fast as it is answered, so slow modes have few samples and the baseline p95 rests on 31 reads.
 
 Four things follow from the numbers.
-The binding rate lands on the grid as designed, four per second against one, and the log shows no rejected proposals, no panics, and no persist errors.
+The binding rate lands on the grid as designed, four per second against one, and the log shows no panics and no persist errors, only shard finalization warnings from the harness dropping and recreating the source between modes.
+The deferred and rejected proposal counters did not exist in this run, so the frequency of either path is unmeasured.
 Event-driven bindings without a lead cut median staleness from about one second to 300 ms, which is the pipeline latency plus a fraction of the grid, and the read tail of 254 ms is the wait for the next binding that the lead section predicts.
 The lead removes that tail, 254 ms to 22 ms at p95, and pays for it in staleness, 299 ms to 581 ms at the median, so the lead is a read latency instrument and not a freshness instrument, and the sum of read latency and staleness is about the same in both event-driven modes.
 The baseline with a one second keepalive shows a 950 ms median read latency, which is the since rounding effect the Binding lead section describes: the source since is floored to the second, the oracle read timestamp lags by up to a second, and every read is pushed to the since and waits for the next keepalive.
@@ -322,6 +326,7 @@ It is complementary and is the natural next design once the budget formula above
 ## Open questions
 
 * How should the wall-clock lag metric account for the lead? Uppers ahead of wall clock read as zero lag. Each writer can announce its lead through source statistics so the controller subtracts it, or the metric can be anchored on the mint wall clock rather than the binding timestamp. Deferred until the prototype shows how large `H` is in practice.
+* How often does arrival-driven minting go inert because ingestion trails the probed upstream frontier? The prototype measured one unfiltered PostgreSQL table, where the two coincide. A Kafka source under load and a PostgreSQL source on a filtered publication are the two shapes to measure next, with the rejected-proposal counter as the instrument.
 * Should the lead default to zero? The prototype shows the lead trading staleness for read tail latency one for one. If freshness is the goal, a zero lead with the read tail bounded by `X_min` may be the better default, with the lead reserved for environments that care about read latency.
 * Can `X_min` adapt to observed consensus latency at the controller level, so that a struggling consensus store widens binding intervals across all sources instead of relying on operator tuning?
 * Should the demand-driven keepalive distinguish reads that touch no table, which only need the oracle advanced and not a txns shard append?

--- a/doc/developer/design/20260912_tickless_frontiers.md
+++ b/doc/developer/design/20260912_tickless_frontiers.md
@@ -1,0 +1,261 @@
+# Tickless frontiers: event-driven timestamp bindings
+
+- Associated: [database-issues#7020] (reclock to latest upper), [database-issues#8885] (probe alignment), [PER-38] (consensus write scalability), [#35046] (reclock to latest is the only variant)
+
+[database-issues#7020]: https://github.com/MaterializeInc/database-issues/issues/7020
+[database-issues#8885]: https://github.com/MaterializeInc/database-issues/issues/8885
+[PER-38]: https://linear.app/materializeinc/issue/PER-38
+[#35046]: https://github.com/MaterializeInc/materialize/pull/35046
+
+## The problem
+
+Every frontier in Materialize advances on a fixed wall-clock ticker, the `timestamp_interval`, which defaults to one second and is pinned to one second by `min_timestamp_interval` and `max_timestamp_interval` (`src/sql/src/session/vars/definitions.rs`).
+Sources mint one remap binding per tick from a probe of the upstream system, tables receive one keepalive group commit per tick, and every dependent collection advances its upper in lockstep.
+The tick is a batching window that trades freshness for load on three external systems: the persist consensus store, the timestamp oracle, and the upstream databases we probe.
+Lowering the interval multiplies all three costs by the same factor, so the interval has stayed at one second even though sub-second freshness is a recurring product ask.
+
+The freshness cost of the tick is structural, not incidental.
+Under reclock-to-latest-upper, data committed upstream just after a probe waits for the next probe before it receives a Materialize timestamp, up to a full interval.
+The binding then needs the persist append and controller propagation before the new upper is visible to the coordinator, which a 2023 measurement put at roughly 300 ms.
+A strict serializable read whose oracle timestamp falls inside that window blocks until the upper becomes visible, so the tick adds latency on the read path as well as staleness on the write path.
+The 2024 rollout of reclock-to-latest-upper measured exactly this regression in strict serializable query latency and considered minting bindings one second into the future to hide it.
+
+The load side is equally structural.
+Table 1 lists the durable writes one idle tick costs at the defaults, verified against the current tree.
+Tables are already amortized through txn-wal and cost nothing per table, but each source costs two compare-and-set operations and each materialized view one, whether or not any data moved.
+Production fleets run on the order of ten thousand consensus writes per second at a one second tick, and the consensus store is a major infrastructure cost that scales linearly with that rate, so the fleet cannot absorb a ten times faster tick as-is.
+
+| Cost center | Durable writes per idle tick | Where |
+|---|---|---|
+| Timestamp oracle | 2 `UPDATE`, 1 `SELECT` | `src/adapter/src/coord/appends.rs` |
+| Catalog shard | 1 compare-and-append | `src/catalog/src/durable/persist.rs` |
+| txns shard | 1 compare-and-append, 1 compare-and-downgrade-since | `src/txn-wal/src/txn_write.rs`, `src/storage-controller/src/persist_handles.rs` |
+| Table data shards | 0 | `src/storage-client/src/storage_collections.rs` |
+| Each source | 1 for the remap shard, 1 per export data shard | `src/storage/src/source/reclock.rs`, `src/storage/src/render/persist_sink.rs` |
+| Each materialized view | 1 (empty batch) | `src/compute/src/sink/materialized_view.rs` |
+| Each introspection collection | 1 | `src/storage-controller/src/collection_mgmt.rs` |
+
+Table 1: Durable writes per idle tick at the default configuration.
+
+Two facts about the current implementation shape the design space.
+First, sources never consult the timestamp oracle: the binding timestamp is the clusterd wall clock floored to the interval (`src/storage/src/source/probe.rs`), and the oracle is only written by the coordinator's group commit.
+Second, reclock-to-latest-upper is the only reclocking strategy since [#35046], so a binding always maps a probed upstream frontier, never the ingested one, and the remap operator mints from a probe stream rather than from the data frontier (`src/storage/src/source/source_reader_pipeline.rs`).
+The critical path for a fresher binding is therefore acquiring the upstream frontier and committing the binding, not any oracle round trip.
+
+## Success criteria
+
+* End-to-end freshness, measured from upstream commit to the moment a strict serializable read can observe the row, is bounded by the ingestion pipeline latency plus a configurable minimum binding interval, and the design supports that interval down to 100 ms within the consensus budget stated below. Today the bound is the pipeline latency plus one second.
+* Strict serializable read latency on a source that is receiving data does not regress relative to today. In particular, reads must not wait for upper visibility on every request.
+* Upstream probe load per source does not exceed today's: at most one explicit probe per source per maximum binding interval, and no explicit probes while the replication stream itself carries the upstream frontier.
+* Durable storage stays bounded: the live size of a remap shard depends on the retention window and partition count, not on the binding rate or the age of the source.
+* Restart is deterministic: the remap shard remains the only source of truth for the mapping, and two replicas or two incarnations of a source produce identical reclocked output.
+* Consensus write rate is an explicit, configurable budget with a documented formula, and the default configuration does not increase the fleet-wide write rate.
+* At an unchanged maximum binding interval, idle collections cost no more durable writes than today, and the environment-level keepalive costs nothing while no reads arrive.
+
+## Out of scope
+
+* Amortizing consensus writes across shards, for example by routing source exports or materialized views through a txn-wal style shared shard. This is the enabler for binding intervals well below 250 ms at fleet scale and gets its own design. This document sizes the budget it would have to meet.
+* Introspection and managed collections. They advance on a hardcoded one second tick in the storage controller, independent of `timestamp_interval`, and are unaffected here.
+* Sinks. A Kafka sink commits one transaction per input frontier step, so a finer input frontier multiplies sink commits. This document requires that sink input frontiers be quantized and leaves the sink-side cadence knob to a follow-up.
+* Bounded staleness and serializable isolation. They do not anchor to source uppers in a way this design changes.
+* A durable raw transaction log written before reclocking. See Alternatives.
+
+## Solution proposal
+
+Frontiers advance when work arrives, bounded below by a minimum binding interval and above by a maximum binding interval, and bindings are minted slightly ahead of wall clock by a measured lead so that fresh uppers are visible by the time a read asks for them.
+Timestamps keep millisecond granularity, and frontiers advance in steps whose size is set by load rather than by a ticker.
+Downstream collections quantize their input frontiers so that a finer source frontier does not multiply their own durable writes.
+The timeline advances on demand rather than on a keepalive ticker, so that read timestamps track wall clock without paying for keepalives when nothing is reading.
+
+```mermaid
+flowchart LR
+    subgraph upstream
+        U[upstream log]
+    end
+    subgraph clusterd
+        R[source reader] -->|data, in-stream tip| M[remap operator]
+        T[idle timer X_max] --> M
+        M -->|"binding (tip, t)"| RS[(remap shard)]
+        RS --> RC[reclock]
+        R --> RC
+        RC --> PS[persist sink] --> DS[(data shard)]
+    end
+    subgraph envd
+        C[coordinator] -->|read wants ts > upper| P[poke, optional]
+        P -.-> M
+    end
+    U --> R
+    DS -->|upper| C
+```
+
+### Terminology
+
+* `X_min`, the minimum binding interval. No source mints two bindings closer than `X_min` apart. It bounds the consensus write rate of a busy source to two writes per `X_min`.
+* `X_max`, the maximum binding interval. An idle source mints a binding at least every `X_max`. It bounds staleness and explicit upstream probe rate for idle sources and is the freshness floor of `mz_now()` driven semantics such as temporal filters. It is the existing `TIMESTAMP INTERVAL`.
+* `H`, the binding lead. A binding minted at wall clock `w` carries timestamp `w + H` rather than `w`. `H` is measured per source, not configured.
+* `Q`, the quantization step of a downstream collection. Its input frontier is only allowed to advance at multiples of `Q`.
+
+### Bindings
+
+The remap operator mints a binding whenever one of three triggers fires and at least `X_min` has elapsed since the previous binding.
+The first trigger is an advance of the upstream frontier observed in the replication stream itself, described per source below.
+The second is the idle timer, which fires `X_max` after the previous binding and performs an explicit probe.
+The third is a poke from the controller on behalf of a waiting read, which is optional and discussed under Alternatives.
+The binding timestamp is `max(now_ms + H, previous_binding + 1)`, floored to the `X_min` grid so that independent sources land on the same timestamps and a join of several sources sees one input frontier step per grid point rather than one per source ([database-issues#8885] describes the cost of misalignment).
+
+The existing `ReclockOperator::mint` contract already enforces what the triggers need.
+It only writes a binding if the upstream frontier is not behind the previously bound frontier and the target upper strictly advances (`src/storage/src/source/reclock.rs`), and it resyncs on a compare-and-append mismatch.
+An arrival-driven proposal whose ingested frontier is still behind the most recently probed upstream tip is rejected by the first condition, so arrival-driven minting only takes effect once ingestion has caught up with the last probe.
+This gives a clean hybrid: while data flows, bindings track the ingested frontier at `X_min` granularity, and at least every `X_max` an explicit probe re-establishes the reclock-to-latest-upper property that a broken upstream connection stalls the source rather than silently advancing it.
+
+Bindings remain monotone in both coordinates by construction, and multiple transactions that arrive within one `X_min` share a timestamp.
+The upstream total order survives as a happens-before relation: transactions with distinct bindings keep their order, transactions with the same binding are simultaneous.
+This is the same guarantee reclocking gives today at one second granularity (`doc/developer/design/20220411_reclocking_implementation.md`).
+
+### Upstream frontier acquisition
+
+Bounded upstream load requires that a busy source learns the upstream frontier from the data it already receives, and only probes explicitly when idle.
+
+| Source | In-stream frontier | Explicit probe today | Under this design |
+|---|---|---|---|
+| PostgreSQL | `wal_end` in every `XLogData` and `PrimaryKeepAlive` message, already used for the data frontier (`src/storage/src/source/postgres/replication.rs`) | `pg_current_wal_lsn()` once per tick | Mint from `wal_end`. The existing one second standby status update with the reply flag set requests a keepalive when idle, so the idle probe is free. Drop the separate probe task. |
+| Kafka | High watermark per partition in every fetch response, cached by the client library | List-offsets metadata fetch per tick per partition | Mint from cached watermarks of consumed partitions. Keep the metadata fetch at `X_max` for partition discovery. |
+| MySQL | None. Binlog heartbeats are not wired to the capability (`src/storage/src/source/mysql/replication.rs`) | `@@global.gtid_executed` once per tick | Arrival-driven bindings bound the ingested frontier. Explicit probe stays at `X_max`. |
+| SQL Server | None, the source polls | `fn_cdc_get_max_lsn()` once per tick | Poll cadence is the binding cadence. `X_min` and `X_max` set the poll interval bounds. |
+| Load generator | Synthesized | Synthesized per tick | Unchanged, minting at `X_max`. |
+
+Table 2: How each source learns the upstream frontier.
+
+### Binding lead
+
+Without a lead, finer bindings make strict serializable reads slower, not faster.
+Today a binding at second `S` covers the interval `[S, S+1)`, and a read whose oracle timestamp falls after the new upper has become visible proceeds immediately, so only reads in the first few hundred milliseconds of each second wait.
+With millisecond bindings and no lead, the visible upper always trails wall clock by the pipeline latency, so every read at an oracle timestamp near wall clock waits for the next binding to propagate.
+The lead `H` restores the property that the visible upper is ahead of wall clock: a binding minted at `w` with timestamp `w + H` becomes visible at roughly `w + L`, where `L` is the pipeline latency, so choosing `H` at or slightly above `L` keeps reads unblocked.
+
+Each source measures `L` locally as an exponentially weighted average of the time from mint to compare-and-append acknowledgement, plus a fixed allowance for controller propagation, and sets `H` from it, clamped to `[0, X_max]`.
+The label a row receives is its upstream commit time plus at most `H + X_min`, which stays inside today's envelope of commit time plus one second as long as `H + X_min <= X_max`.
+The lead is a labeling choice and does not change what data exists at any upstream position, so determinism on restart is unaffected.
+The lead does interact with the wall-clock lag metric, which compares uppers to wall clock and would read the lead as negative lag. See Open questions.
+
+### Timeline advancement on demand
+
+The coordinator's keepalive group commit exists so that the oracle read timestamp tracks wall clock and tables remain readable at it (`src/adapter/src/coord/appends.rs`).
+Under this design the keepalive fires on demand instead of on a ticker: when a strict serializable read finds the oracle read timestamp more than `X_min` behind wall clock, it triggers one keepalive commit and waits for it, coalescing with other waiting reads.
+The precedent is the nudge in `src/adapter/src/frontend_read_then_write.rs`, which asks for a commit instead of waiting a full interval.
+An idle timer at `X_max` keeps `mz_now()` moving for temporal filters and refresh schedules when no reads arrive.
+A sparse read therefore pays one group commit of latency in exchange for a read timestamp within `X_min` of wall clock, where today it reads for free at a timestamp up to one second stale.
+The per-environment cost is unchanged under read load and drops to zero when idle, and all of the correctness argument goes through the oracle exactly as today, so the invariants in `doc/developer/guide-adapter.md` hold.
+
+Read timestamp selection itself does not change.
+Later timestamps are always safe within a read's real-time bounds, and every advancement of the oracle happens through `apply_write`, so the distributed and monotonicity requirements of the adapter guide are preserved.
+This design does not pick read timestamps from source uppers, which the 2023 latency-versus-freshness exploration rejected because a source with a skewed clock could drag the oracle forward.
+
+### Frontier quantization downstream
+
+A materialized view appends one batch per input frontier step, whether or not data moved, and a Kafka sink commits one transaction per step.
+Finer source frontiers therefore multiply downstream durable writes unless downstream collections quantize.
+A quantizer sits at the input of every dataflow that feeds a durable sink and only passes the input frontier at multiples of `Q`, leaving data timestamps untouched.
+The existing temporal bucketing operator in compute (`compute_temporal_bucketing_summary`) shows that coarsening frontiers without changing data timestamps is already an established pattern in the rendering layer.
+
+`Q` defaults to `X_min` for materialized views, which preserves alignment without adding delay, and to `X_max` for sinks, which preserves today's sink cadence.
+Both are per-collection knobs so that a specific materialized view can trade consensus writes for freshness.
+The quantizer is also the natural place for an adaptive policy later: a sink that observes slow commits can widen `Q` on its own.
+
+### Storage growth
+
+A binding adds one row per changed partition to the remap shard, encoded as an increment so that rows consolidate (`doc/developer/design/20220411_reclocking_implementation.md`).
+Compaction consolidates all rows below the shard's since into one row per partition, and the since follows the data shard's since, which lags the upper by the compaction window.
+The live row count of a remap shard is therefore the binding rate times the compaction window plus one row per partition, and is independent of source age.
+At the proposed defaults that is a handful of rows per source.
+
+Persist state grows with the number of compare-and-set operations only transiently.
+Each successful append adds a batch that the spine merges, a rollup is written every 128 sequence numbers, and garbage collection truncates consensus every 32, so state size is bounded by spine invariants and blob count by the merge schedule, both proportional to write rate but not to age.
+The data shard sees the same pattern because empty batches do not add parts.
+Nothing new is stored: the design changes when existing writes happen, not what is written.
+
+### Determinism on restart
+
+The remap shard is written before any data is reclocked, and the reclock operator holds its capability until the reader has read through the binding (`src/timely-util/src/reclock.rs`), so the data shard upper never exceeds the remap shard upper.
+On restart the source reads the data shard upper, maps it back to an upstream position through the remap shard (`reclock_committed_upper` in `src/storage/src/source/source_reader_pipeline.rs`), resumes upstream from there, and re-ingested data receives the bindings already on record.
+Arrival-driven minting and the lead do not touch this argument, because both only decide which timestamp a new binding proposes, and proposals become truth only through the compare-and-append on the remap shard.
+Two replicas racing to mint resolve through the same compare-and-append, the loser resyncs to the winner's bindings, and both reclock identically, which the existing concurrency test in `src/storage/src/source/reclock.rs` exercises.
+
+### Consensus budget
+
+The durable write rate of the system under this design is
+
+* per busy source: `2 / X_min`
+* per idle source: `2 / X_max`
+* per materialized view: `1 / Q`
+* per environment: `3 / X_min` under read load for oracle, catalog, and txns shard writes, zero when idle
+
+At `X_min = 250 ms` and `X_max = 1 s`, an idle shard writes exactly what it writes today and a busy shard writes four times more, so the fleet-wide rate grows with the fraction of busy shards.
+Idle shards only get cheaper when `X_max` is raised, which trades idle staleness and a slower `mz_now()` floor for consensus writes, and is a per-environment choice.
+`X_min` defaults to 250 ms and is configurable per environment, so a fleet with many busy shards can raise it back to `X_max` to reproduce today's write rate exactly.
+The self-adjusting behavior the problem statement asks for comes from two places: while an append is in flight, arrivals accumulate into the next binding, so steps grow with load, and `X_min` caps the rate when arrivals trickle.
+Amortizing appends across shards is what makes `X_min` well below 250 ms affordable at fleet scale, and is out of scope here.
+
+### Configuration and rollout
+
+* `X_max` is the existing `TIMESTAMP INTERVAL` source option and `default_timestamp_interval`, with unchanged meaning.
+* `X_min` is a new dyncfg `storage_min_binding_interval`, defaulting to 250 ms. Setting it to `X_max` reproduces today's cadence.
+* Event-driven minting and the lead are behind a feature flag that defaults off in production and on in CI, wired through `system_parameter_default` so that sqllogictest, testdrive, and platform checks exercise the new path.
+* The lead `H` is observable per source through source statistics.
+* `Q` is a per-collection option with the defaults above.
+
+## Minimal viable prototype
+
+The prototype covers the PostgreSQL source and the load generator, because PostgreSQL already carries the upstream frontier in-stream and the load generator gives a controlled arrival rate.
+It implements arrival-driven minting with `X_min` and `X_max`, the measured lead, and the demand-driven keepalive, and leaves quantization at its default of `Q = X_min`.
+The measurements are end-to-end freshness as the difference between upstream commit time and first visibility in a strict serializable read, strict serializable read latency distribution, compare-and-set rate per shard from persist metrics, and explicit probe count against the upstream database.
+Success is a freshness median below `X_min` plus pipeline latency at unchanged read latency and unchanged probe count, with the consensus rate matching the budget formula.
+
+## Alternatives
+
+### Lower the timestamp interval globally
+
+Setting `default_timestamp_interval` to 100 ms gives ten times finer bindings with no code change.
+It also multiplies every row of Table 1 by ten, including upstream probes and idle shards, and keeps the read-path latency problem because bindings are still minted at probe time without a lead.
+It is the baseline the prototype is measured against.
+
+### Coordinator poke instead of a lead
+
+Instead of minting ahead of wall clock, a strict serializable read whose timestamp exceeds a source upper could ask the controller to have the source mint now.
+This keeps labels at upstream commit time but adds a controller-to-cluster protocol with coalescing across many waiting reads, and every such read still pays the full propagation latency.
+The lead achieves unblocked reads without a protocol.
+The poke remains useful as a targeted mechanism for reads against sources that are idle for longer than `X_max` and could be added later.
+
+### Durable raw log, then deterministic reclocking
+
+The problem statement proposes writing the ingested transaction log durably first, reclocking deterministically in a second step, and garbage collecting reclocked input.
+The upstream system already is that durable log: PostgreSQL slots are advanced only after data is durable in persist, Kafka retains by policy, and MySQL retains binlogs, so the current pipeline resumes from upstream deterministically without a copy (`src/storage/src/source/source_reader_pipeline.rs`).
+A shard keyed by upstream time would also need a fixed-width codec for `Partitioned` timestamps, which does not exist, and reclock-to-latest-upper assigns timestamps from bindings minted before the data arrives, so timestamps cannot be derived from arrival into a raw log.
+The proposal solves a problem the pipeline does not have.
+
+### Non-durable frontier announcements
+
+A source could announce "no data before `t`" to downstream consumers without a compare-and-set, relying on wall clock monotonicity across restarts to never mint below `t`.
+A downstream materialized view that sealed times below `t` on that promise would then be wrong if a restarted or skewed replica mints below `t`, silently and permanently.
+Frontiers are promises and promises must be durable, so this is rejected.
+
+### Mint a constant distance into the future
+
+The 2023 exploration proposed minting source timestamps a fixed one or two seconds ahead and widening the compaction window to match.
+A fixed lead either exceeds the pipeline latency, adding staleness for nothing, or falls short of it under load, reintroducing read waits.
+The measured lead in this design is the same idea with the constant replaced by the quantity it was approximating.
+
+### Amortize consensus writes first
+
+Routing source exports and materialized views through a shared shard, in the way txn-wal already does for tables, would let one compare-and-set advance many collections and make small `X_min` affordable everywhere.
+It does not by itself improve freshness, because bindings would still be minted per tick, and it does not reduce upstream probes.
+It is complementary and is the natural next design once the budget formula above is confirmed by measurement.
+
+## Open questions
+
+* How should the wall-clock lag metric account for the lead? Uppers ahead of wall clock read as zero lag. Each writer can announce its lead through source statistics so the controller subtracts it, or the metric can be anchored on the mint wall clock rather than the binding timestamp. Deferred until the prototype shows how large `H` is in practice.
+* Can `X_min` adapt to observed consensus latency at the controller level, so that a struggling consensus store widens binding intervals across all sources instead of relying on operator tuning?
+* For MySQL, should the explicit probe cadence while data flows be `X_max`, which makes the source reclock-to-latest-upper only once per `X_max`, or should the binlog heartbeat be wired into the capability to provide an in-stream frontier?
+* Does the Kafka client library expose the cached high watermark to the source without a network round trip in the way the source needs, including after a rebalance?
+* Which tests encode the one second tick as an assumption? The rollout flag being on in CI will surface them, and they need review rather than blanket relaxation.
+* Should `TIMESTAMP INTERVAL` eventually mean `X_min` rather than `X_max`, since users who set it are asking for freshness rather than for an idle cadence? Its one second default reads as an idle cadence today, so it stays `X_max` for now and the question is deferred until `X_min` has a user-facing surface.

--- a/doc/developer/design/20260912_tickless_frontiers.md
+++ b/doc/developer/design/20260912_tickless_frontiers.md
@@ -111,7 +111,7 @@ The second is the idle timer, which fires `X_max` after the previous binding and
 Both triggers produce a proposal `(frontier, probe_ts)`, and the remap operator must wake on a changed frontier even when the timestamp is unchanged, because two arrivals inside one grid cell carry the same timestamp and today's wake condition compares timestamps only.
 
 The binding timestamp is `floor_grid(probe_ts + H)`, where `floor_grid` rounds down to the `X_min` grid and `probe_ts` is the wall clock at which the proposal was made, already on the `X_max` grid for explicit probes.
-A proposal whose floored timestamp is not at or beyond the current remap upper is deferred to the start of the next grid cell rather than dropped, so the explicit `X_max` probe is never lost to an arrival probe that used the same cell.
+A proposal whose floored timestamp is not at or beyond the current remap upper is deferred to the start of the next grid cell rather than dropped, and a probe arriving in the meantime replaces the held one only if its frontier is at least as advanced, so the explicit `X_max` probe is not lost to an arrival probe that used the same cell.
 Taking the maximum with the previous binding instead would mint off the grid at arrival rate whenever arrivals are faster than the grid, which defeats the rate bound.
 The target upper is derived from the final timestamp, because `mint` asserts that the upper is beyond the binding timestamp.
 Deferred proposals and proposals that `mint` rejects because their frontier is behind the recorded one each carry a per-source counter, because under arrival-driven minting both are normal and a stuck source would otherwise be indistinguishable from a healthy one.

--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -3516,6 +3516,20 @@ metrics:
   - worker_id
   source: src/storage/src/statistics.rs
   visibility: internal
+- name: mz_source_remap_proposals_deferred_total
+  help: Remap binding proposals deferred to the next grid cell because the remap upper was already beyond them
+  labels:
+  - source_id
+  - worker_id
+  source: src/storage/src/metrics/source.rs
+  visibility: internal
+- name: mz_source_remap_proposals_rejected_total
+  help: Remap binding proposals that `mint` did not append because the proposed source frontier was behind the recorded one
+  labels:
+  - source_id
+  - worker_id
+  source: src/storage/src/metrics/source.rs
+  visibility: internal
 - name: mz_source_row_inserts
   help: A counter representing the actual number of rows being inserted to the data shard
   labels:

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -572,7 +572,13 @@ def get_variable_system_parameters(
             ["", "0", "1", "1000", "2071", "1000000"],
         ),
         VariableSystemParameter(
+            "storage_binding_lead", "0ms", ["0ms", "250ms", "500ms"]
+        ),
+        VariableSystemParameter(
             "storage_event_driven_bindings", "true", ["true", "false"]
+        ),
+        VariableSystemParameter(
+            "storage_min_binding_interval", "250ms", ["100ms", "250ms", "1s"]
         ),
         VariableSystemParameter(
             "storage_source_decode_fuel",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -572,6 +572,9 @@ def get_variable_system_parameters(
             ["", "0", "1", "1000", "2071", "1000000"],
         ),
         VariableSystemParameter(
+            "storage_event_driven_bindings", "true", ["true", "false"]
+        ),
+        VariableSystemParameter(
             "storage_source_decode_fuel",
             "100000",
             ["10000", "100000", "1000000"],

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -2998,6 +2998,20 @@ class FlipFlagsAction(Action):
             "'1s'",
             "'10s'",
         ]
+        self.flags_with_values["storage_event_driven_bindings"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["storage_min_binding_interval"] = [
+            "'100ms'",
+            "'250ms'",
+            "'1s'",
+        ]
+        # The lead must stay below the default one second compaction window
+        # minus the binding interval, otherwise strict serializable reads wait
+        # on the source since.
+        self.flags_with_values["storage_binding_lead"] = [
+            "'0ms'",
+            "'250ms'",
+            "'500ms'",
+        ]
         self.flags_with_values["arrangement_size_history_collection_interval"] = [
             "'1s'",
             "'10s'",

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -303,6 +303,38 @@ pub static PG_SOURCE_VALIDATE_TIMELINE: Config<bool> = Config::new(
     ParameterScope::Environment,
 );
 
+// Reclocking
+
+/// Whether sources mint remap bindings when their data frontier advances, in
+/// addition to the periodic upstream probe.
+///
+/// Environment scoped because bindings are shared truth across the replicas of
+/// a cluster and all replicas must propose timestamps on the same grid.
+pub const STORAGE_EVENT_DRIVEN_BINDINGS: Config<bool> = Config::new(
+    "storage_event_driven_bindings",
+    false,
+    "Whether sources mint remap bindings when their data frontier advances, in addition to the periodic upstream probe.",
+    ParameterScope::Environment,
+);
+
+/// The grid to which event-driven binding timestamps are floored. Two bindings
+/// of one source are never closer than this.
+pub const STORAGE_MIN_BINDING_INTERVAL: Config<Duration> = Config::new(
+    "storage_min_binding_interval",
+    Duration::from_millis(250),
+    "The grid to which event-driven remap binding timestamps are floored. Two bindings of one source are never closer than this.",
+    ParameterScope::Environment,
+);
+
+/// Lead added to event-driven binding timestamps so that a binding's upper is
+/// visible to the coordinator by the time wall clock reaches it.
+pub const STORAGE_BINDING_LEAD: Config<Duration> = Config::new(
+    "storage_binding_lead",
+    Duration::ZERO,
+    "Lead added to event-driven remap binding timestamps.",
+    ParameterScope::Environment,
+);
+
 /// Controls behavior of the SQL Server source when the upstream DB restore history changes. The
 /// default behavior is to emit a definite error, forcing source recreation.  In cases of Always
 /// On Availability Group (AOAG), the upstream DB may guarantee continuity without loss of data.
@@ -554,7 +586,10 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&SINK_ENSURE_TOPIC_CONFIG)
         .add(&SINK_PROGRESS_SEARCH)
         .add(&SQL_SERVER_SOURCE_VALIDATE_RESTORE_HISTORY)
+        .add(&STORAGE_BINDING_LEAD)
         .add(&STORAGE_DOWNGRADE_SINCE_DURING_FINALIZATION)
+        .add(&STORAGE_EVENT_DRIVEN_BINDINGS)
+        .add(&STORAGE_MIN_BINDING_INTERVAL)
         .add(&STORAGE_ROCKSDB_CLEANUP_TRIES)
         .add(&STORAGE_ROCKSDB_USE_MERGE_OPERATOR)
         .add(&STORAGE_SERVER_MAINTENANCE_INTERVAL)

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -303,6 +303,21 @@ pub static PG_SOURCE_VALIDATE_TIMELINE: Config<bool> = Config::new(
     ParameterScope::Environment,
 );
 
+/// Controls behavior of the SQL Server source when the upstream DB restore history changes. The
+/// default behavior is to emit a definite error, forcing source recreation.  In cases of Always
+/// On Availability Group (AOAG), the upstream DB may guarantee continuity without loss of data.
+/// Changing this flag puts the onus on the customer to recreate the source if the upstream DB
+/// changes in a way that introduces data loss.
+/// Environment-scoped because it decides whether a definite error is emitted.
+/// Replicas of one cluster disagreeing would write different collection
+/// contents, so the value has to be coherent across them.
+pub static SQL_SERVER_SOURCE_VALIDATE_RESTORE_HISTORY: Config<bool> = Config::new(
+    "sql_server_source_validate_restore_history",
+    true,
+    "Whether to treat a restore history change as a definite error",
+    ParameterScope::Environment,
+);
+
 // Reclocking
 
 /// Whether sources mint remap bindings when their data frontier advances, in
@@ -332,21 +347,6 @@ pub const STORAGE_BINDING_LEAD: Config<Duration> = Config::new(
     "storage_binding_lead",
     Duration::ZERO,
     "Lead added to event-driven remap binding timestamps.",
-    ParameterScope::Environment,
-);
-
-/// Controls behavior of the SQL Server source when the upstream DB restore history changes. The
-/// default behavior is to emit a definite error, forcing source recreation.  In cases of Always
-/// On Availability Group (AOAG), the upstream DB may guarantee continuity without loss of data.
-/// Changing this flag puts the onus on the customer to recreate the source if the upstream DB
-/// changes in a way that introduces data loss.
-/// Environment-scoped because it decides whether a definite error is emitted.
-/// Replicas of one cluster disagreeing would write different collection
-/// contents, so the value has to be coherent across them.
-pub static SQL_SERVER_SOURCE_VALIDATE_RESTORE_HISTORY: Config<bool> = Config::new(
-    "sql_server_source_validate_restore_history",
-    true,
-    "Whether to treat a restore history change as a definite error",
     ParameterScope::Environment,
 );
 

--- a/src/storage/src/metrics/source.rs
+++ b/src/storage/src/metrics/source.rs
@@ -37,6 +37,8 @@ pub(crate) struct GeneralSourceMetricDefs {
     pub(crate) resume_upper: IntGaugeVec,
     pub(crate) commit_upper_ready_times: UIntGaugeVec,
     pub(crate) commit_upper_accepted_times: UIntGaugeVec,
+    pub(crate) remap_proposals_deferred: IntCounterVec,
+    pub(crate) remap_proposals_rejected: IntCounterVec,
 
     // OffsetCommitMetrics
     pub(crate) offset_commit_failures: IntCounterVec,
@@ -71,6 +73,16 @@ impl GeneralSourceMetricDefs {
             commit_upper_accepted_times: registry.register(metric!(
                 name: "mz_source_commit_upper_accepted_times",
                 help: "The number of accepted remap bindings that are held in the reclock commit upper operator.",
+                var_labels: ["source_id", "worker_id"],
+            )),
+            remap_proposals_deferred: registry.register(metric!(
+                name: "mz_source_remap_proposals_deferred_total",
+                help: "Remap binding proposals deferred to the next grid cell because the remap upper was already beyond them",
+                var_labels: ["source_id", "worker_id"],
+            )),
+            remap_proposals_rejected: registry.register(metric!(
+                name: "mz_source_remap_proposals_rejected_total",
+                help: "Remap binding proposals that `mint` did not append because the proposed source frontier was behind the recorded one",
                 var_labels: ["source_id", "worker_id"],
             )),
             offset_commit_failures: registry.register(metric!(
@@ -123,6 +135,12 @@ pub(crate) struct SourceMetrics {
     pub(crate) commit_upper_ready_times: DeleteOnDropGauge<AtomicU64, Vec<String>>,
     /// The number of accepted remap bindings that are held in the reclock commit upper operator.
     pub(crate) commit_upper_accepted_times: DeleteOnDropGauge<AtomicU64, Vec<String>>,
+    /// Remap binding proposals deferred to the next grid cell because the remap upper was already
+    /// beyond them.
+    pub(crate) remap_proposals_deferred_total: DeleteOnDropCounter<AtomicU64, Vec<String>>,
+    /// Remap binding proposals that `mint` did not append because the proposed source frontier was
+    /// behind the recorded one.
+    pub(crate) remap_proposals_rejected_total: DeleteOnDropCounter<AtomicU64, Vec<String>>,
 }
 
 impl SourceMetrics {
@@ -141,6 +159,12 @@ impl SourceMetrics {
                 .get_delete_on_drop_metric(vec![source_id.to_string(), worker_id.to_string()]),
             commit_upper_accepted_times: defs
                 .commit_upper_accepted_times
+                .get_delete_on_drop_metric(vec![source_id.to_string(), worker_id.to_string()]),
+            remap_proposals_deferred_total: defs
+                .remap_proposals_deferred
+                .get_delete_on_drop_metric(vec![source_id.to_string(), worker_id.to_string()]),
+            remap_proposals_rejected_total: defs
+                .remap_proposals_rejected
                 .get_delete_on_drop_metric(vec![source_id.to_string(), worker_id.to_string()]),
         }
     }

--- a/src/storage/src/source/probe.rs
+++ b/src/storage/src/source/probe.rs
@@ -18,12 +18,9 @@ use mz_ore::cast::CastFrom;
 use mz_ore::now::{EpochMillis, NowFn};
 use mz_repr::{GlobalId, Timestamp};
 use mz_timely_util::builder_async::{Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder};
-use timely::Container;
 use timely::container::CapacityContainerBuilder;
+use timely::dataflow::StreamVec;
 use timely::dataflow::channels::pact::Pipeline;
-use timely::dataflow::operators::CapabilitySet;
-use timely::dataflow::operators::generic::builder_rc::OperatorBuilder as OperatorBuilderRc;
-use timely::dataflow::{Stream, StreamVec};
 use timely::progress::{Antichain, Timestamp as TimelyTimestamp};
 use tracing::trace;
 
@@ -137,31 +134,6 @@ pub(super) fn floor_to_grid(ts: Timestamp, grid: Duration) -> Timestamp {
     Timestamp::from(ms - (ms % grid_ms))
 }
 
-/// Forwards only the frontier of `stream`, dropping every record.
-pub(super) fn progress_only<'scope, T, C>(
-    stream: &Stream<'scope, T, C>,
-) -> StreamVec<'scope, T, Infallible>
-where
-    T: TimelyTimestamp,
-    C: Container + Clone + 'static,
-{
-    let mut builder = OperatorBuilderRc::new("progress_only".into(), stream.scope());
-    let (_output, progress) = builder.new_output::<Vec<Infallible>>();
-    let mut input = builder.new_input(stream.clone(), Pipeline);
-
-    builder.build(move |caps| {
-        let mut cap_set =
-            CapabilitySet::from_elem(caps.into_iter().next().expect("one capability per output"));
-        move |frontiers| {
-            // Records must be consumed for the input frontier to advance.
-            input.for_each(|_cap, _data| {});
-            cap_set.downgrade(frontiers[0].frontier().iter());
-        }
-    });
-
-    progress
-}
-
 /// Emits a probe whenever the frontier of `progress` advances, at most once per `min_interval`.
 ///
 /// Runs on one worker chosen by `source_id`. Never emits the minimum frontier, so the first
@@ -269,6 +241,7 @@ mod tests {
         assert_eq!(floor_to_grid(ts(1000), grid), ts(1000));
         assert_eq!(floor_to_grid(ts(1249), grid), ts(1000));
         assert_eq!(floor_to_grid(ts(1250), grid), ts(1250));
+        assert_eq!(floor_to_grid(ts(7), grid), ts(0));
         assert_eq!(floor_to_grid(ts(7), Duration::ZERO), ts(7));
     }
 }

--- a/src/storage/src/source/probe.rs
+++ b/src/storage/src/source/probe.rs
@@ -18,6 +18,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::now::{EpochMillis, NowFn};
 use mz_repr::{GlobalId, Timestamp};
 use mz_timely_util::builder_async::{Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder};
+use timely::PartialOrder;
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::StreamVec;
 use timely::dataflow::channels::pact::Pipeline;
@@ -152,12 +153,14 @@ pub(super) fn ceil_to_grid(ts: Timestamp, grid: Duration) -> Timestamp {
 
 /// Emits a probe whenever the frontier of `progress` advances, at most once per `min_interval`.
 ///
-/// Runs on one worker chosen by `source_id`. Never emits the minimum frontier, so the first
-/// binding of a source stays the snapshot binding, and never emits an empty frontier, which the
+/// Runs on one worker chosen by `source_id`. Only emits frontiers at or beyond the most advanced
+/// one seen on `explicit`, the source's own probe stream, so the first binding of a source stays
+/// the snapshot binding minted from an explicit probe. Never emits an empty frontier, which the
 /// remap operator treats as source shutdown.
 pub(super) fn arrival_probes<'scope, T: TimelyTimestamp>(
     source_id: GlobalId,
     progress: StreamVec<'scope, T, Infallible>,
+    explicit: StreamVec<'scope, T, Probe<T>>,
     min_interval: Duration,
     now_fn: NowFn,
 ) -> StreamVec<'scope, T, Probe<T>> {
@@ -169,6 +172,7 @@ pub(super) fn arrival_probes<'scope, T: TimelyTimestamp>(
     let mut op = AsyncOperatorBuilder::new("arrival_probes".into(), scope);
     let (output, output_stream) = op.new_output::<CapacityContainerBuilder<_>>();
     let mut input = op.new_input_for(progress, Pipeline, &output);
+    let mut explicit_input = op.new_input_for(explicit, Pipeline, &output);
 
     op.build(|caps| async move {
         if !is_active_worker {
@@ -182,6 +186,9 @@ pub(super) fn arrival_probes<'scope, T: TimelyTimestamp>(
         let mut frontier = minimum_frontier.clone();
         let mut last_emit: Option<EpochMillis> = None;
         let mut pending = false;
+        // The most advanced frontier an explicit probe has reported so far.
+        let mut probed: Option<Antichain<T>> = None;
+        let mut explicit_open = true;
 
         loop {
             // The sleep is only armed while a frontier advance waits for the rate limit to
@@ -203,6 +210,17 @@ pub(super) fn arrival_probes<'scope, T: TimelyTimestamp>(
                             continue;
                         }
                         frontier = new_frontier;
+                        // A proposal behind the last explicit probe would be rejected by
+                        // `mint`, and before the first explicit probe it would become the
+                        // snapshot binding with only part of the snapshot in it. Only
+                        // frontiers at or beyond the probed one are proposed.
+                        let eligible = probed
+                            .as_ref()
+                            .is_some_and(|probed| PartialOrder::less_equal(probed, &frontier));
+                        if !eligible {
+                            pending = false;
+                            continue;
+                        }
 
                         let now = now_fn();
                         if last_emit.is_none_or(|last| now >= last.saturating_add(min_ms)) {
@@ -224,6 +242,20 @@ pub(super) fn arrival_probes<'scope, T: TimelyTimestamp>(
                     // constructible event and carries no information.
                     Some(AsyncEvent::Data(..)) => (),
                     None => return,
+                },
+                event = explicit_input.next(), if explicit_open => match event {
+                    Some(AsyncEvent::Data(_, probes)) => {
+                        for probe in probes {
+                            let advanced = probed.as_ref().is_none_or(|probed| {
+                                PartialOrder::less_equal(probed, &probe.upstream_frontier)
+                            });
+                            if advanced {
+                                probed = Some(probe.upstream_frontier);
+                            }
+                        }
+                    }
+                    Some(AsyncEvent::Progress(_)) => (),
+                    None => explicit_open = false,
                 },
                 _ = tokio::time::sleep(wait), if pending => {
                     let now = now_fn();

--- a/src/storage/src/source/probe.rs
+++ b/src/storage/src/source/probe.rs
@@ -9,11 +9,25 @@
 
 //! Support for sending frontier probes to upstream systems.
 
+use std::convert::Infallible;
 use std::time::Duration;
 
+use differential_dataflow::Hashable;
+use futures::StreamExt;
+use mz_ore::cast::CastFrom;
 use mz_ore::now::{EpochMillis, NowFn};
-use mz_repr::Timestamp;
+use mz_repr::{GlobalId, Timestamp};
+use mz_timely_util::builder_async::{Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder};
+use timely::Container;
+use timely::container::CapacityContainerBuilder;
+use timely::dataflow::channels::pact::Pipeline;
+use timely::dataflow::operators::CapabilitySet;
+use timely::dataflow::operators::generic::builder_rc::OperatorBuilder as OperatorBuilderRc;
+use timely::dataflow::{Stream, StreamVec};
+use timely::progress::{Antichain, Timestamp as TimelyTimestamp};
 use tracing::trace;
+
+use crate::source::types::Probe;
 
 /// A ticker to drive source upstream probing.
 ///
@@ -108,5 +122,153 @@ impl<G: Fn() -> Duration> Ticker<G> {
 
     fn round_to_interval(&self, ms: EpochMillis) -> EpochMillis {
         ms - (ms % self.interval)
+    }
+}
+
+/// Floors `ts` to the largest multiple of `grid` that is not greater than it.
+///
+/// A zero grid leaves `ts` unchanged.
+pub(super) fn floor_to_grid(ts: Timestamp, grid: Duration) -> Timestamp {
+    let grid_ms = u64::try_from(grid.as_millis()).unwrap_or(u64::MAX);
+    if grid_ms == 0 {
+        return ts;
+    }
+    let ms = u64::from(ts);
+    Timestamp::from(ms - (ms % grid_ms))
+}
+
+/// Forwards only the frontier of `stream`, dropping every record.
+pub(super) fn progress_only<'scope, T, C>(
+    stream: &Stream<'scope, T, C>,
+) -> StreamVec<'scope, T, Infallible>
+where
+    T: TimelyTimestamp,
+    C: Container + Clone + 'static,
+{
+    let mut builder = OperatorBuilderRc::new("progress_only".into(), stream.scope());
+    let (_output, progress) = builder.new_output::<Vec<Infallible>>();
+    let mut input = builder.new_input(stream.clone(), Pipeline);
+
+    builder.build(move |caps| {
+        let mut cap_set =
+            CapabilitySet::from_elem(caps.into_iter().next().expect("one capability per output"));
+        move |frontiers| {
+            // Records must be consumed for the input frontier to advance.
+            input.for_each(|_cap, _data| {});
+            cap_set.downgrade(frontiers[0].frontier().iter());
+        }
+    });
+
+    progress
+}
+
+/// Emits a probe whenever the frontier of `progress` advances, at most once per `min_interval`.
+///
+/// Runs on one worker chosen by `source_id`. Never emits the minimum frontier, so the first
+/// binding of a source stays the snapshot binding, and never emits an empty frontier, which the
+/// remap operator treats as source shutdown.
+pub(super) fn arrival_probes<'scope, T: TimelyTimestamp>(
+    source_id: GlobalId,
+    progress: StreamVec<'scope, T, Infallible>,
+    min_interval: Duration,
+    now_fn: NowFn,
+) -> StreamVec<'scope, T, Probe<T>> {
+    let scope = progress.scope();
+
+    let active_worker = usize::cast_from(source_id.hashed()) % scope.peers();
+    let is_active_worker = active_worker == scope.index();
+
+    let mut op = AsyncOperatorBuilder::new("arrival_probes".into(), scope);
+    let (output, output_stream) = op.new_output::<CapacityContainerBuilder<_>>();
+    let mut input = op.new_input_for(progress, Pipeline, &output);
+
+    op.build(|caps| async move {
+        if !is_active_worker {
+            return;
+        }
+
+        let [cap] = caps.try_into().expect("one capability per output");
+
+        let min_ms = u64::try_from(min_interval.as_millis()).unwrap_or(u64::MAX);
+        let minimum_frontier = Antichain::from_elem(T::minimum());
+        let mut frontier = minimum_frontier.clone();
+        let mut last_emit: Option<EpochMillis> = None;
+        let mut pending = false;
+
+        loop {
+            // The sleep is only armed while a frontier advance waits for the rate limit to
+            // expire, so the `Duration::MAX` fallback is never slept on.
+            let wait = match (pending, last_emit) {
+                (true, Some(last)) => {
+                    Duration::from_millis(last.saturating_add(min_ms).saturating_sub(now_fn()))
+                }
+                _ => Duration::MAX,
+            };
+
+            tokio::select! {
+                event = input.next() => match event {
+                    Some(AsyncEvent::Progress(new_frontier)) => {
+                        if new_frontier == frontier
+                            || new_frontier == minimum_frontier
+                            || new_frontier.is_empty()
+                        {
+                            continue;
+                        }
+                        frontier = new_frontier;
+
+                        let now = now_fn();
+                        if last_emit.is_none_or(|last| now >= last.saturating_add(min_ms)) {
+                            trace!(
+                                "arrival_probes({source_id}) probing at {now}: \
+                                frontier advanced"
+                            );
+                            output.give(&cap, Probe {
+                                probe_ts: now.into(),
+                                upstream_frontier: frontier.clone(),
+                            });
+                            last_emit = Some(now);
+                            pending = false;
+                        } else {
+                            pending = true;
+                        }
+                    }
+                    Some(AsyncEvent::Data(..)) => unreachable!("progress-only stream"),
+                    None => return,
+                },
+                _ = tokio::time::sleep(wait), if pending => {
+                    let now = now_fn();
+                    trace!(
+                        "arrival_probes({source_id}) probing at {now}: rate limit expired"
+                    );
+                    output.give(&cap, Probe {
+                        probe_ts: now.into(),
+                        upstream_frontier: frontier.clone(),
+                    });
+                    last_emit = Some(now);
+                    pending = false;
+                }
+            }
+        }
+    });
+
+    output_stream
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use mz_repr::Timestamp;
+
+    use super::floor_to_grid;
+
+    #[mz_ore::test]
+    fn floor_to_grid_rounds_down_to_multiples() {
+        let grid = Duration::from_millis(250);
+        let ts = Timestamp::from;
+        assert_eq!(floor_to_grid(ts(1000), grid), ts(1000));
+        assert_eq!(floor_to_grid(ts(1249), grid), ts(1000));
+        assert_eq!(floor_to_grid(ts(1250), grid), ts(1250));
+        assert_eq!(floor_to_grid(ts(7), Duration::ZERO), ts(7));
     }
 }

--- a/src/storage/src/source/probe.rs
+++ b/src/storage/src/source/probe.rs
@@ -126,12 +126,28 @@ impl<G: Fn() -> Duration> Ticker<G> {
 ///
 /// A zero grid leaves `ts` unchanged.
 pub(super) fn floor_to_grid(ts: Timestamp, grid: Duration) -> Timestamp {
-    let grid_ms = u64::try_from(grid.as_millis()).unwrap_or(u64::MAX);
+    let ms = u64::from(ts);
+    let Ok(grid_ms) = u64::try_from(grid.as_millis()) else {
+        // A grid wider than the timestamp domain puts every timestamp in the first cell, which
+        // starts at the minimum timestamp.
+        return Timestamp::MIN;
+    };
     if grid_ms == 0 {
         return ts;
     }
-    let ms = u64::from(ts);
     Timestamp::from(ms - (ms % grid_ms))
+}
+
+/// Returns the start of the first multiple of `grid` that is not less than `ts`.
+///
+/// A zero grid leaves `ts` unchanged.
+pub(super) fn ceil_to_grid(ts: Timestamp, grid: Duration) -> Timestamp {
+    let floored = floor_to_grid(ts, grid);
+    if floored == ts {
+        return ts;
+    }
+    let grid_ms = u64::try_from(grid.as_millis()).unwrap_or(u64::MAX);
+    Timestamp::from(u64::from(floored).saturating_add(grid_ms))
 }
 
 /// Emits a probe whenever the frontier of `progress` advances, at most once per `min_interval`.
@@ -204,7 +220,9 @@ pub(super) fn arrival_probes<'scope, T: TimelyTimestamp>(
                             pending = true;
                         }
                     }
-                    Some(AsyncEvent::Data(..)) => unreachable!("progress-only stream"),
+                    // The upstream operator pushes no records, but an empty batch is still a
+                    // constructible event and carries no information.
+                    Some(AsyncEvent::Data(..)) => (),
                     None => return,
                 },
                 _ = tokio::time::sleep(wait), if pending => {
@@ -232,7 +250,7 @@ mod tests {
 
     use mz_repr::Timestamp;
 
-    use super::floor_to_grid;
+    use super::{ceil_to_grid, floor_to_grid};
 
     #[mz_ore::test]
     fn floor_to_grid_rounds_down_to_multiples() {
@@ -243,5 +261,16 @@ mod tests {
         assert_eq!(floor_to_grid(ts(1250), grid), ts(1250));
         assert_eq!(floor_to_grid(ts(7), grid), ts(0));
         assert_eq!(floor_to_grid(ts(7), Duration::ZERO), ts(7));
+        assert_eq!(floor_to_grid(ts(1000), Duration::MAX), ts(0));
+    }
+
+    #[mz_ore::test]
+    fn ceil_to_grid_rounds_up_to_multiples() {
+        let grid = Duration::from_millis(250);
+        let ts = Timestamp::from;
+        assert_eq!(ceil_to_grid(ts(1000), grid), ts(1000));
+        assert_eq!(ceil_to_grid(ts(1001), grid), ts(1250));
+        assert_eq!(ceil_to_grid(ts(7), grid), ts(250));
+        assert_eq!(ceil_to_grid(ts(7), Duration::ZERO), ts(7));
     }
 }

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -202,12 +202,18 @@ where
 
     let timestamp_desc = source_connection.timestamp_desc();
 
+    // The flag is read once per dataflow, so the operator that emits arrival probes and the
+    // operator that turns them into bindings always agree. A flip that reached only one of the two
+    // would mint bindings off the grid at the arrival probe rate.
+    let event_driven = STORAGE_EVENT_DRIVEN_BINDINGS.get(config.config.config_set());
+
     let (remap_collection, remap_token) = remap_operator(
         scope,
         storage_state,
         config.clone(),
         probed_upper_rx,
         timestamp_desc,
+        event_driven,
     );
     // Need to broadcast the remap changes to all workers.
     let remap_collection = remap_collection.inner.broadcast().as_collection();
@@ -232,6 +238,7 @@ where
             probed_upper_tx,
             committed_upper,
             start_signal,
+            event_driven,
         );
 
         for (id, export) in exports {
@@ -272,6 +279,7 @@ fn source_render_operator<'scope, C>(
     probed_upper_tx: watch::Sender<Option<Probe<C::Time>>>,
     resume_uppers: impl futures::Stream<Item = Antichain<C::Time>> + 'static,
     start_signal: impl std::future::Future<Output = ()> + 'static,
+    event_driven: bool,
 ) -> (
     BTreeMap<GlobalId, StackedCollection<'scope, C::Time, Result<SourceMessage, DataflowError>>>,
     StreamVec<'scope, C::Time, HealthStatusMessage>,
@@ -308,9 +316,6 @@ where
 
     let mut health_streams = vec![];
 
-    // Whether arrival probes exist is decided here, once, so that the rendered graph with the
-    // flag off is the graph we have today.
-    let event_driven = STORAGE_EVENT_DRIVEN_BINDINGS.get(config.config.config_set());
     let mut progress_streams = vec![];
 
     for (id, export) in exports {
@@ -327,6 +332,9 @@ where
 
         // Republishing the export's frontier here rather than tapping the data stream keeps the
         // export single-consumer, so its `Tee` never clones a batch of source records.
+        //
+        // The output handle stays unused because the operator only downgrades this output's
+        // capability and never pushes a record onto it.
         let _progress_output = event_driven.then(|| {
             let (output, progress) = builder.new_output::<Vec<Infallible>>();
             progress_streams.push(progress);
@@ -454,6 +462,7 @@ fn remap_operator<'scope, FromTime>(
     config: RawSourceCreationConfig,
     mut probed_upper: watch::Receiver<Option<Probe<FromTime>>>,
     remap_relation_desc: RelationDesc,
+    event_driven: bool,
 ) -> (
     VecCollection<'scope, mz_repr::Timestamp, FromTime, Diff>,
     PressOnDropButton,
@@ -472,7 +481,7 @@ where
         as_of,
         resume_uppers: _,
         source_resume_uppers: _,
-        metrics: _,
+        metrics,
         now_fn,
         persist_clients,
         statistics: _,
@@ -483,10 +492,6 @@ where
     } = config;
 
     let config_set = Arc::clone(storage_config.config_set());
-    // Whether arrival probes exist is decided once, when the dataflow is rendered, so the binding
-    // rule is fixed at the same moment. A flip that reached only one of the two would mint
-    // ungridded bindings at the arrival probe rate.
-    let event_driven = STORAGE_EVENT_DRIVEN_BINDINGS.get(&config_set);
 
     let read_only_rx = storage_state.read_only_rx.clone();
     let error_handler = storage_state.error_handler("remap_operator", id);
@@ -549,36 +554,88 @@ where
         let mut remap_upper = initial_batch.upper.clone();
         cap_set.downgrade(initial_batch.upper);
 
+        let source_metrics = metrics.get_source_metrics(id, worker_id);
+
         let mut prev_probe: Option<Probe<FromTime>> = None;
+        // A proposal whose grid cell the remap upper has already passed is held here until that
+        // cell ends, rather than dropped. An explicit probe can land in a cell an arrival probe
+        // already used, and dropping it would lose the guarantee that an explicit probe mints a
+        // binding at least every `X_max`.
+        let mut deferred: Option<Probe<FromTime>> = None;
+
+        // We only mint bindings after a successful probe. Under event-driven minting probes
+        // arrive from two producers, so a probe with an unchanged timestamp but an advanced
+        // frontier is new information. `less_than` is that "new information" test and, unlike
+        // inequality, does not depend on the order in which a partitioned frontier lists its
+        // elements.
+        let is_fresh =
+            |prev: &Option<Probe<FromTime>>, new: &Option<Probe<FromTime>>| match (prev, new) {
+                (None, Some(_)) => true,
+                (Some(prev), Some(new)) => {
+                    prev.probe_ts < new.probe_ts
+                        || (event_driven
+                            && PartialOrder::less_than(
+                                &prev.upstream_frontier,
+                                &new.upstream_frontier,
+                            ))
+                }
+                _ => false,
+            };
+        // The watch sender is dropped when the source shuts down. The empty frontier stands in
+        // for it and makes `mint` close the remap shard.
+        let shutdown_probe = || Probe {
+            probe_ts: now_fn().into(),
+            upstream_frontier: Antichain::new(),
+        };
 
         while !cap_set.is_empty() {
-            // We only mint bindings after a successful probe.
-            let new_probe = probed_upper
-                .wait_for(|new_probe| match (&prev_probe, new_probe) {
-                    (None, Some(_)) => true,
-                    (Some(prev), Some(new)) => {
-                        // Under event-driven minting probes arrive from two producers, so a probe
-                        // with an unchanged timestamp but an advanced frontier is new information.
-                        prev.probe_ts < new.probe_ts
-                            || (event_driven && prev.upstream_frontier != new.upstream_frontier)
+            let probe = match deferred.take() {
+                None => probed_upper
+                    .wait_for(|new_probe| is_fresh(&prev_probe, new_probe))
+                    .await
+                    .map(|probe| (*probe).clone())
+                    .unwrap_or_else(|_| Some(shutdown_probe()))
+                    .expect("known to be Some"),
+                Some(held) => {
+                    let grid = STORAGE_MIN_BINDING_INTERVAL.get(&config_set);
+                    let cell_start = remap_upper
+                        .as_option()
+                        .map_or(mz_repr::Timestamp::MIN, |upper| {
+                            probe::ceil_to_grid(*upper, grid)
+                        });
+                    let wait =
+                        Duration::from_millis(u64::from(cell_start).saturating_sub(now_fn()));
+                    let fresh_probe =
+                        probed_upper.wait_for(|new_probe| is_fresh(&prev_probe, new_probe));
+                    tokio::select! {
+                        result = fresh_probe => {
+                            // A newer probe carries a frontier at least as advanced as the held
+                            // one, so it replaces it.
+                            result
+                                .map(|probe| (*probe).clone())
+                                .unwrap_or_else(|_| Some(shutdown_probe()))
+                                .expect("known to be Some")
+                        }
+                        _ = tokio::time::sleep(wait) => Probe {
+                            probe_ts: now_fn().into(),
+                            upstream_frontier: held.upstream_frontier,
+                        },
                     }
-                    _ => false,
-                })
-                .await
-                .map(|probe| (*probe).clone())
-                .unwrap_or_else(|_| {
-                    Some(Probe {
-                        probe_ts: now_fn().into(),
-                        upstream_frontier: Antichain::new(),
-                    })
-                });
+                }
+            };
 
-            let probe = new_probe.expect("known to be Some");
             prev_probe = Some(probe.clone());
 
-            // The empty frontier signals source shutdown, which mints its final binding at the
-            // probe timestamp regardless of the grid.
-            let binding_ts = if event_driven && !probe.upstream_frontier.is_empty() {
+            let binding_ts = if probe.upstream_frontier.is_empty() {
+                // The empty frontier signals source shutdown. Its binding has to be at or beyond
+                // the remap upper, else `mint` refuses it and the shard never closes. With
+                // event-driven bindings off the upper never leads `now`, so the maximum is a
+                // no-op there.
+                let now = probe.probe_ts;
+                remap_upper
+                    .as_option()
+                    .map_or(now, |upper| std::cmp::max(now, *upper))
+            } else if event_driven {
                 let lead = STORAGE_BINDING_LEAD.get(&config_set);
                 let grid = STORAGE_MIN_BINDING_INTERVAL.get(&config_set);
                 let lead_ms = u64::try_from(lead.as_millis()).unwrap_or(u64::MAX);
@@ -586,14 +643,17 @@ where
                     mz_repr::Timestamp::from(u64::from(probe.probe_ts).saturating_add(lead_ms));
                 let binding_ts = probe::floor_to_grid(led, grid);
                 // A proposal inside the grid cell of the current upper would be rejected by
-                // `mint` without a diagnostic. Skipping it here keeps bindings on the grid and
-                // bounds the compare-and-append rate.
+                // `mint` without a diagnostic. Deferring it to the next cell keeps bindings on
+                // the grid and bounds the compare-and-append rate, where taking the maximum with
+                // the upper instead would mint off the grid at the arrival rate.
                 if !remap_upper.less_equal(&binding_ts) {
                     trace!(
-                        "timely-{worker_id} remap({id}) skipping proposal at {binding_ts}: \
+                        "timely-{worker_id} remap({id}) deferring proposal at {binding_ts}: \
                         remap upper {} is beyond it",
                         remap_upper.pretty()
                     );
+                    source_metrics.remap_proposals_deferred_total.inc();
+                    deferred = Some(probe);
                     continue;
                 }
                 binding_ts
@@ -607,6 +667,13 @@ where
             let mut remap_trace_batch = timestamper
                 .mint(binding_ts, new_into_upper, cur_source_upper.borrow())
                 .await;
+
+            // Under event-driven minting a rejection is the normal case while ingestion catches
+            // up with the last explicit probe, so it needs a counter to stay distinguishable from
+            // a source that is stuck.
+            if !cur_source_upper.is_empty() && remap_trace_batch.upper == remap_upper {
+                source_metrics.remap_proposals_rejected_total.inc();
+            }
 
             trace!(
                 "timely-{worker_id} remap({id}) minted new bindings: \

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -40,6 +40,9 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_repr::{Diff, GlobalId, RelationDesc, Row};
 use mz_storage_types::configuration::StorageConfiguration;
 use mz_storage_types::controller::CollectionMetadata;
+use mz_storage_types::dyncfgs::{
+    STORAGE_BINDING_LEAD, STORAGE_EVENT_DRIVEN_BINDINGS, STORAGE_MIN_BINDING_INTERVAL,
+};
 use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sources::{SourceConnection, SourceExport, SourceTimestamp};
 use mz_timely_util::antichain::AntichainExt;
@@ -55,7 +58,7 @@ use timely::dataflow::operators::core::Map as _;
 use timely::dataflow::operators::generic::OutputBuilder;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder as OperatorBuilderRc;
 use timely::dataflow::operators::vec::Broadcast;
-use timely::dataflow::operators::{CapabilitySet, InspectCore, Leave};
+use timely::dataflow::operators::{CapabilitySet, Concat, Concatenate, InspectCore, Leave};
 use timely::dataflow::{Scope, StreamVec};
 use timely::order::TotalOrder;
 use timely::progress::frontier::MutableAntichain;
@@ -67,6 +70,7 @@ use tracing::trace;
 use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate};
 use crate::metrics::StorageMetrics;
 use crate::metrics::source::SourceMetrics;
+use crate::source::probe;
 use crate::source::reclock::ReclockOperator;
 use crate::source::types::{Probe, SourceMessage, SourceOutput, SourceRender, StackedCollection};
 use crate::statistics::SourceStatistics;
@@ -381,6 +385,22 @@ where
         });
     }
 
+    // Event-driven bindings add a second probe source, driven by the frontier of the data the
+    // source has already produced rather than by a poll of the upstream system.
+    let probe_stream = if STORAGE_EVENT_DRIVEN_BINDINGS.get(config.config.config_set()) {
+        let min_interval = STORAGE_MIN_BINDING_INTERVAL.get(config.config.config_set());
+        let progress_streams: Vec<_> = export_collections
+            .values()
+            .map(|collection| probe::progress_only(&collection.inner))
+            .collect();
+        let progress = scope.concatenate(progress_streams);
+        let arrival =
+            probe::arrival_probes(source_id, progress, min_interval, config.now_fn.clone());
+        probe_stream.concat(arrival)
+    } else {
+        probe_stream
+    };
+
     // Broadcasting does more work than necessary, which would be to exchange the probes to the
     // worker that will be the one minting the bindings but we'd have to thread this information
     // through and couple the two functions enough that it's not worth the optimization (I think).
@@ -441,10 +461,12 @@ where
         persist_clients,
         statistics: _,
         shared_remap_upper,
-        config: _,
+        config: storage_config,
         remap_collection_id,
         busy_signal: _,
     } = config;
+
+    let config_set = Arc::clone(storage_config.config_set());
 
     let read_only_rx = storage_state.read_only_rx.clone();
     let error_handler = storage_state.error_handler("remap_operator", id);
@@ -504,16 +526,26 @@ where
         let cap = cap_set.delayed(cap_set.first().unwrap());
         remap_output.give_container(&cap, &mut initial_batch.updates);
         drop(cap);
+        let mut remap_upper = initial_batch.upper.clone();
         cap_set.downgrade(initial_batch.upper);
 
-        let mut prev_probe_ts: Option<mz_repr::Timestamp> = None;
+        let mut prev_probe: Option<Probe<FromTime>> = None;
 
         while !cap_set.is_empty() {
+            // Both the wake condition and the binding timestamp depend on the flag, so it is read
+            // once per iteration to keep the two coherent across a flip.
+            let event_driven = STORAGE_EVENT_DRIVEN_BINDINGS.get(&config_set);
+
             // We only mint bindings after a successful probe.
             let new_probe = probed_upper
-                .wait_for(|new_probe| match (prev_probe_ts, new_probe) {
+                .wait_for(|new_probe| match (&prev_probe, new_probe) {
                     (None, Some(_)) => true,
-                    (Some(prev_ts), Some(new)) => prev_ts < new.probe_ts,
+                    (Some(prev), Some(new)) => {
+                        // Under event-driven minting probes arrive from two producers, so a probe
+                        // with an unchanged timestamp but an advanced frontier is new information.
+                        prev.probe_ts < new.probe_ts
+                            || (event_driven && prev.upstream_frontier != new.upstream_frontier)
+                    }
                     _ => false,
                 })
                 .await
@@ -526,9 +558,32 @@ where
                 });
 
             let probe = new_probe.expect("known to be Some");
-            prev_probe_ts = Some(probe.probe_ts);
+            prev_probe = Some(probe.clone());
 
-            let binding_ts = probe.probe_ts;
+            // The empty frontier signals source shutdown, which mints its final binding at the
+            // probe timestamp regardless of the grid.
+            let binding_ts = if event_driven && !probe.upstream_frontier.is_empty() {
+                let lead = STORAGE_BINDING_LEAD.get(&config_set);
+                let grid = STORAGE_MIN_BINDING_INTERVAL.get(&config_set);
+                let lead_ms = u64::try_from(lead.as_millis()).unwrap_or(u64::MAX);
+                let led =
+                    mz_repr::Timestamp::from(u64::from(probe.probe_ts).saturating_add(lead_ms));
+                let binding_ts = probe::floor_to_grid(led, grid);
+                // A proposal inside the grid cell of the current upper would be rejected by
+                // `mint` without a diagnostic. Skipping it here keeps bindings on the grid and
+                // bounds the compare-and-append rate.
+                if !remap_upper.less_equal(&binding_ts) {
+                    trace!(
+                        "timely-{worker_id} remap({id}) skipping proposal at {binding_ts}: \
+                        remap upper {} is beyond it",
+                        remap_upper.pretty()
+                    );
+                    continue;
+                }
+                binding_ts
+            } else {
+                probe.probe_ts
+            };
             let cur_source_upper = probe.upstream_frontier;
 
             let new_into_upper = Antichain::from_elem(binding_ts.step_forward());
@@ -549,6 +604,7 @@ where
 
             let cap = cap_set.delayed(cap_set.first().unwrap());
             remap_output.give_container(&cap, &mut remap_trace_batch.updates);
+            remap_upper.clone_from(&remap_trace_batch.upper);
             cap_set.downgrade(remap_trace_batch.upper);
         }
     });

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -25,6 +25,7 @@
 
 use std::cell::RefCell;
 use std::collections::{BTreeMap, VecDeque};
+use std::convert::Infallible;
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
 use std::sync::Arc;
@@ -307,6 +308,11 @@ where
 
     let mut health_streams = vec![];
 
+    // Whether arrival probes exist is decided here, once, so that the rendered graph with the
+    // flag off is the graph we have today.
+    let event_driven = STORAGE_EVENT_DRIVEN_BINDINGS.get(config.config.config_set());
+    let mut progress_streams = vec![];
+
     for (id, export) in exports {
         let name = format!("SourceGenericStats({})", id);
         let mut builder = OperatorBuilderRc::new(name, scope.clone());
@@ -319,6 +325,14 @@ where
         let (output, new_export) = builder.new_output();
         let mut output = OutputBuilder::<_, CapacityContainerBuilder<_>>::from(output);
 
+        // Republishing the export's frontier here rather than tapping the data stream keeps the
+        // export single-consumer, so its `Tee` never clones a batch of source records.
+        let _progress_output = event_driven.then(|| {
+            let (output, progress) = builder.new_output::<Vec<Infallible>>();
+            progress_streams.push(progress);
+            output
+        });
+
         let mut input = builder.new_input(export.inner, Pipeline);
         export_collections.insert(id, new_export.as_collection());
 
@@ -330,9 +344,15 @@ where
             .clone();
 
         builder.build(move |mut caps| {
+            let mut progress_cap_set = event_driven
+                .then(|| CapabilitySet::from_elem(caps.pop().expect("one capability per output")));
             let mut health_cap = Some(caps.remove(0));
 
             move |frontiers| {
+                if let Some(cap_set) = &mut progress_cap_set {
+                    cap_set.downgrade(frontiers[0].frontier().iter());
+                }
+
                 let mut last_status = None;
                 let mut health_output = health_output.activate();
 
@@ -387,12 +407,8 @@ where
 
     // Event-driven bindings add a second probe source, driven by the frontier of the data the
     // source has already produced rather than by a poll of the upstream system.
-    let probe_stream = if STORAGE_EVENT_DRIVEN_BINDINGS.get(config.config.config_set()) {
+    let probe_stream = if event_driven {
         let min_interval = STORAGE_MIN_BINDING_INTERVAL.get(config.config.config_set());
-        let progress_streams: Vec<_> = export_collections
-            .values()
-            .map(|collection| probe::progress_only(&collection.inner))
-            .collect();
         let progress = scope.concatenate(progress_streams);
         let arrival =
             probe::arrival_probes(source_id, progress, min_interval, config.now_fn.clone());
@@ -467,6 +483,10 @@ where
     } = config;
 
     let config_set = Arc::clone(storage_config.config_set());
+    // Whether arrival probes exist is decided once, when the dataflow is rendered, so the binding
+    // rule is fixed at the same moment. A flip that reached only one of the two would mint
+    // ungridded bindings at the arrival probe rate.
+    let event_driven = STORAGE_EVENT_DRIVEN_BINDINGS.get(&config_set);
 
     let read_only_rx = storage_state.read_only_rx.clone();
     let error_handler = storage_state.error_handler("remap_operator", id);
@@ -532,10 +552,6 @@ where
         let mut prev_probe: Option<Probe<FromTime>> = None;
 
         while !cap_set.is_empty() {
-            // Both the wake condition and the binding timestamp depend on the flag, so it is read
-            // once per iteration to keep the two coherent across a flip.
-            let event_driven = STORAGE_EVENT_DRIVEN_BINDINGS.get(&config_set);
-
             // We only mint bindings after a successful probe.
             let new_probe = probed_upper
                 .wait_for(|new_probe| match (&prev_probe, new_probe) {

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -609,12 +609,22 @@ where
                         probed_upper.wait_for(|new_probe| is_fresh(&prev_probe, new_probe));
                     tokio::select! {
                         result = fresh_probe => {
-                            // A newer probe carries a frontier at least as advanced as the held
-                            // one, so it replaces it.
-                            result
+                            let new_probe = result
                                 .map(|probe| (*probe).clone())
                                 .unwrap_or_else(|_| Some(shutdown_probe()))
-                                .expect("known to be Some")
+                                .expect("known to be Some");
+                            // An arrival probe carries the ingested data frontier, which is
+                            // normally behind an explicit probe's upstream frontier. Replace the
+                            // held probe only if the new one is at least as advanced, so the
+                            // explicit probe's frontier is not lost.
+                            if PartialOrder::less_equal(
+                                &held.upstream_frontier,
+                                &new_probe.upstream_frontier,
+                            ) {
+                                new_probe
+                            } else {
+                                held
+                            }
                         }
                         _ = tokio::time::sleep(wait) => Probe {
                             probe_ts: now_fn().into(),

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -418,8 +418,13 @@ where
     let probe_stream = if event_driven {
         let min_interval = STORAGE_MIN_BINDING_INTERVAL.get(config.config.config_set());
         let progress = scope.concatenate(progress_streams);
-        let arrival =
-            probe::arrival_probes(source_id, progress, min_interval, config.now_fn.clone());
+        let arrival = probe::arrival_probes(
+            source_id,
+            progress,
+            probe_stream.clone(),
+            min_interval,
+            config.now_fn.clone(),
+        );
         probe_stream.concat(arrival)
     } else {
         probe_stream

--- a/src/storage/src/statistics.rs
+++ b/src/storage/src/statistics.rs
@@ -798,11 +798,21 @@ impl SourceStatistics {
         cur.prom.offset_known.set(value);
     }
 
-    /// Set the `offset_committed` stat to the given value.
+    /// Set the `offset_committed` stat to the given value, raising `offset_known`
+    /// to at least the same value.
     pub fn set_offset_committed(&self, value: u64) {
         let mut cur = self.stats.borrow_mut();
         cur.stats.offset_committed = Some(Some(value));
         cur.prom.offset_committed.set(value);
+        // A committed offset exists upstream by definition. Bindings minted from
+        // the data frontier can commit past the last upstream probe, which is
+        // what refreshes `offset_known`, so the invariant `known >= committed`
+        // is enforced here rather than left to probe timing.
+        let known = cur.stats.offset_known.flatten().unwrap_or(0);
+        if known < value {
+            cur.stats.offset_known = Some(Some(value));
+            cur.prom.offset_known.set(value);
+        }
     }
 
     /// Set the `snapshot_records_known` stat to the given value.

--- a/test/kafka-auth/test-schema-registry-ssl-basic.td
+++ b/test/kafka-auth/test-schema-registry-ssl-basic.td
@@ -135,8 +135,14 @@ $ kafka-ingest topic=avro-data format=avro schema=${schema} timestamp=2
 1
 2
 
+# The sink only reports the stall once its 60s transaction timeout against the
+# broken broker expires, so the check needs a longer window than that.
+$ set-sql-timeout duration=120s
+
 > SELECT count(status) > 0 FROM mz_internal.mz_sink_status_history JOIN mz_sinks ON sink_id = id WHERE name = 'snk_backup' AND status = 'stalled';
 true
+
+$ set-sql-timeout duration=60s
 
 > ALTER CONNECTION kafka_backup SET (BROKER 'kafka:9092');
 

--- a/test/testdrive/frontier-rounding.td
+++ b/test/testdrive/frontier-rounding.td
@@ -21,6 +21,11 @@
 # The rounding is currently not working correctly for tables, compute
 # introspection sources, storage-managed collections. See database-issues#9030.
 
+# Event-driven bindings land on the minimum binding interval grid rather than
+# on seconds, so this test pins the plain tick.
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET storage_event_driven_bindings = false
+
 $ kafka-create-topic topic=topic partitions=1
 
 > CREATE CONNECTION kafka_conn
@@ -62,3 +67,6 @@ true
 #   JOIN mz_sources ON id = object_id
 #   WHERE object_id LIKE 's%'
 # true
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM RESET storage_event_driven_bindings

--- a/test/testdrive/source-timestamps.td
+++ b/test/testdrive/source-timestamps.td
@@ -9,6 +9,11 @@
 
 # Tests to verify that source timestamps are rounded to the timestamp interval.
 
+# Event-driven bindings land on the minimum binding interval grid rather than
+# on the timestamp interval, so this test pins the plain tick.
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET storage_event_driven_bindings = false
+
 > CREATE CLUSTER test SIZE 'scale=1,workers=1'
 
 $ kafka-create-topic topic=test
@@ -97,3 +102,6 @@ ALTER SOURCE mysql_src SET (TIMESTAMP INTERVAL = '500ms')
 kafka_src          true
 pg_src             true
 mysql_src          true
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM RESET storage_event_driven_bindings

--- a/test/tickless-spike/README.md
+++ b/test/tickless-spike/README.md
@@ -1,0 +1,18 @@
+# Tickless frontiers spike harness
+
+Measures end-to-end freshness and strict serializable read latency of a
+PostgreSQL source under the event-driven binding flag.
+
+## Setup
+
+    docker run -d --name tickless-pg -p 5434:5432 -e POSTGRES_PASSWORD=postgres postgres:16 -c wal_level=logical
+    docker start cockroach || docker run --name=cockroach -d -p 26257:26257 -p 26258:8080 cockroachdb/cockroach:latest start-single-node --insecure --store=type=mem,size=2G
+    bin/environmentd --reset
+
+## Run
+
+    bin/pyactivate -m pip install psycopg   # only if missing
+    bin/pyactivate test/tickless-spike/spike.py --duration 30 --rate 20
+
+Each mode drops and recreates the source so that dyncfg changes take effect
+at operator build time.

--- a/test/tickless-spike/spike.py
+++ b/test/tickless-spike/spike.py
@@ -1,0 +1,184 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Measure source freshness under event-driven remap bindings."""
+
+import argparse
+import threading
+import time
+from dataclasses import dataclass, field
+
+import psycopg
+
+PG_DSN = "host=localhost port=5434 user=postgres password=postgres dbname=postgres"
+MZ_DSN = "host=localhost port=6875 user=materialize dbname=materialize"
+MZ_SYSTEM_DSN = "host=localhost port=6877 user=mz_system dbname=materialize"
+
+
+@dataclass
+class Mode:
+    name: str
+    event_driven: bool
+    lead_ms: int
+    keepalive_ms: int
+
+
+MODES = [
+    Mode("baseline", False, 0, 1000),
+    Mode("baseline+keepalive250", False, 0, 250),
+    Mode("event-driven lead0", True, 0, 250),
+    Mode("event-driven lead400", True, 400, 250),
+]
+
+
+@dataclass
+class Samples:
+    staleness_ms: list[float] = field(default_factory=list)
+    latency_ms: list[float] = field(default_factory=list)
+    binding_timestamps: set[int] = field(default_factory=set)
+    errors: int = 0
+
+
+def pg_setup() -> None:
+    with psycopg.connect(PG_DSN, autocommit=True) as conn:
+        conn.execute("DROP PUBLICATION IF EXISTS mz_pub")
+        conn.execute("DROP TABLE IF EXISTS t")
+        conn.execute(
+            "CREATE TABLE t (id bigserial PRIMARY KEY, ts timestamptz NOT NULL DEFAULT clock_timestamp())"
+        )
+        conn.execute("ALTER TABLE t REPLICA IDENTITY FULL")
+        conn.execute("CREATE PUBLICATION mz_pub FOR TABLE t")
+
+
+def mz_system(sql: str) -> None:
+    with psycopg.connect(MZ_SYSTEM_DSN, autocommit=True) as conn:
+        conn.execute(sql)
+
+
+def mz_setup(mode: Mode) -> None:
+    mz_system("ALTER SYSTEM SET default_timestamp_interval = '1s'")
+    mz_system(
+        f"ALTER SYSTEM SET storage_event_driven_bindings = {'true' if mode.event_driven else 'false'}"
+    )
+    mz_system(f"ALTER SYSTEM SET storage_binding_lead = '{mode.lead_ms}ms'")
+    with psycopg.connect(MZ_DSN, autocommit=True) as conn:
+        conn.execute("DROP SOURCE IF EXISTS pg_src CASCADE")
+        conn.execute("DROP CONNECTION IF EXISTS pg CASCADE")
+        conn.execute("DROP SECRET IF EXISTS pgpass")
+        conn.execute("CREATE SECRET pgpass AS 'postgres'")
+        conn.execute(
+            "CREATE CONNECTION pg TO POSTGRES (HOST 'localhost', PORT 5434, USER postgres, PASSWORD SECRET pgpass, DATABASE postgres)"
+        )
+        conn.execute("CREATE SOURCE pg_src FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_pub')")
+        conn.execute("CREATE TABLE t FROM SOURCE pg_src (REFERENCE t)")
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            row = conn.execute("SELECT count(*) FROM t").fetchone()
+            if row is not None:
+                break
+            time.sleep(0.5)
+    # Set after CREATE SOURCE so the source keeps a 1s TIMESTAMP INTERVAL and
+    # only the coordinator keepalive speeds up.
+    mz_system(f"ALTER SYSTEM SET default_timestamp_interval = '{mode.keepalive_ms}ms'")
+    time.sleep(3)
+
+
+def writer(stop: threading.Event, rate_hz: float) -> None:
+    period = 1.0 / rate_hz
+    with psycopg.connect(PG_DSN, autocommit=True) as conn:
+        while not stop.is_set():
+            conn.execute("INSERT INTO t DEFAULT VALUES")
+            time.sleep(period)
+
+
+def reader(stop: threading.Event, samples: Samples) -> None:
+    with psycopg.connect(MZ_DSN, autocommit=True) as conn:
+        conn.execute("SET transaction_isolation = 'strict serializable'")
+        while not stop.is_set():
+            t0 = time.time()
+            try:
+                row = conn.execute("SELECT max(ts) FROM t").fetchone()
+            except psycopg.Error:
+                samples.errors += 1
+                time.sleep(0.1)
+                continue
+            t1 = time.time()
+            samples.latency_ms.append((t1 - t0) * 1000.0)
+            if row is not None and row[0] is not None:
+                samples.staleness_ms.append((t1 - row[0].timestamp()) * 1000.0)
+            time.sleep(0.05)
+
+
+def binding_counter(stop: threading.Event, samples: Samples) -> None:
+    with psycopg.connect(MZ_DSN, autocommit=False) as conn:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("DECLARE c CURSOR FOR SUBSCRIBE (SELECT * FROM pg_src_progress)")
+        while not stop.is_set():
+            rows = cur.execute("FETCH ALL c WITH (timeout = '1s')").fetchall()
+            for row in rows:
+                samples.binding_timestamps.add(int(row[0]))
+
+
+def pct(values: list[float], p: float) -> float:
+    if not values:
+        return float("nan")
+    values = sorted(values)
+    idx = min(len(values) - 1, int(round(p * (len(values) - 1))))
+    return values[idx]
+
+
+def run_mode(mode: Mode, duration_s: float, rate_hz: float) -> tuple[Mode, Samples, float]:
+    mz_setup(mode)
+    samples = Samples()
+    stop = threading.Event()
+    threads = [
+        threading.Thread(target=writer, args=(stop, rate_hz), daemon=True),
+        threading.Thread(target=reader, args=(stop, samples), daemon=True),
+        threading.Thread(target=binding_counter, args=(stop, samples), daemon=True),
+    ]
+    for th in threads:
+        th.start()
+    t_start = time.time()
+    time.sleep(duration_s)
+    stop.set()
+    for th in threads:
+        th.join(timeout=5)
+    return mode, samples, time.time() - t_start
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--duration", type=float, default=30.0)
+    parser.add_argument("--rate", type=float, default=20.0)
+    parser.add_argument("--modes", nargs="*", default=[m.name for m in MODES])
+    args = parser.parse_args()
+
+    pg_setup()
+    results = []
+    for mode in MODES:
+        if mode.name not in args.modes:
+            continue
+        results.append(run_mode(mode, args.duration, args.rate))
+
+    print("| mode | staleness p50 ms | staleness p95 ms | read p50 ms | read p95 ms | bindings/s | reads | errors |")
+    print("|---|---|---|---|---|---|---|---|")
+    for mode, s, elapsed in results:
+        print(
+            f"| {mode.name} | {pct(s.staleness_ms, 0.5):.0f} | {pct(s.staleness_ms, 0.95):.0f} "
+            f"| {pct(s.latency_ms, 0.5):.1f} | {pct(s.latency_ms, 0.95):.1f} "
+            f"| {len(s.binding_timestamps) / elapsed:.2f} | {len(s.latency_ms)} | {s.errors} |"
+        )
+    mz_system("ALTER SYSTEM RESET default_timestamp_interval")
+    mz_system("ALTER SYSTEM RESET storage_event_driven_bindings")
+    mz_system("ALTER SYSTEM RESET storage_binding_lead")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/tickless-spike/spike.py
+++ b/test/tickless-spike/spike.py
@@ -78,7 +78,8 @@ def mz_setup(mode: Mode) -> None:
             "CREATE CONNECTION pg TO POSTGRES (HOST 'localhost', PORT 5434, USER postgres, PASSWORD SECRET pgpass, DATABASE postgres)"
         )
         conn.execute(
-            "CREATE SOURCE pg_src FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_pub')"
+            "CREATE SOURCE pg_src FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_pub') "
+            "EXPOSE PROGRESS AS pg_src_progress"
         )
         conn.execute("CREATE TABLE t FROM SOURCE pg_src (REFERENCE t)")
         deadline = time.monotonic() + 60

--- a/test/tickless-spike/spike.py
+++ b/test/tickless-spike/spike.py
@@ -27,11 +27,15 @@ class Mode:
     event_driven: bool
     lead_ms: int
     keepalive_ms: int
+    # The source's TIMESTAMP INTERVAL, which is X_max under the flag and the
+    # plain tick without it.
+    source_interval_ms: int = 1000
 
 
 MODES = [
     Mode("baseline", False, 0, 1000),
     Mode("baseline+keepalive250", False, 0, 250),
+    Mode("tick250", False, 0, 250, 250),
     Mode("event-driven lead0", True, 0, 250),
     Mode("event-driven lead400", True, 400, 250),
 ]
@@ -65,6 +69,7 @@ def mz_system(sql: str) -> None:
 
 def mz_setup(mode: Mode) -> None:
     mz_system("ALTER SYSTEM SET default_timestamp_interval = '1s'")
+    mz_system("ALTER SYSTEM SET min_timestamp_interval = '100ms'")
     mz_system(
         f"ALTER SYSTEM SET storage_event_driven_bindings = {'true' if mode.event_driven else 'false'}"
     )
@@ -79,7 +84,8 @@ def mz_setup(mode: Mode) -> None:
         )
         conn.execute(
             "CREATE SOURCE pg_src FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_pub') "
-            "EXPOSE PROGRESS AS pg_src_progress"
+            "EXPOSE PROGRESS AS pg_src_progress "
+            f"WITH (TIMESTAMP INTERVAL '{mode.source_interval_ms}ms')".encode()
         )
         conn.execute("CREATE TABLE t FROM SOURCE pg_src (REFERENCE t)")
         deadline = time.monotonic() + 60
@@ -139,6 +145,10 @@ def reader(stop: threading.Event, samples: Samples) -> None:
 
 
 def binding_counter(stop: threading.Event, samples: Samples) -> None:
+    # Counts bindings that move the upstream frontier. A binding that repeats
+    # the frontier at a new time consolidates away in the progress collection,
+    # and mz_internal.mz_frontiers only refreshes once per second, so idle
+    # bindings are not observable from SQL.
     with psycopg.connect(MZ_DSN, autocommit=False) as conn:
         cur = conn.cursor()
         cur.execute("DECLARE c CURSOR FOR SUBSCRIBE (SELECT * FROM pg_src_progress)")
@@ -195,6 +205,7 @@ def main() -> None:
         mz_system("ALTER SYSTEM RESET default_timestamp_interval")
         mz_system("ALTER SYSTEM RESET storage_event_driven_bindings")
         mz_system("ALTER SYSTEM RESET storage_binding_lead")
+        mz_system("ALTER SYSTEM RESET min_timestamp_interval")
 
     print(
         "| mode | staleness p50 ms | staleness p95 ms | read p50 ms | read p95 ms | bindings/s | reads | errors |"

--- a/test/tickless-spike/spike.py
+++ b/test/tickless-spike/spike.py
@@ -58,7 +58,9 @@ def pg_setup() -> None:
 
 def mz_system(sql: str) -> None:
     with psycopg.connect(MZ_SYSTEM_DSN, autocommit=True) as conn:
-        conn.execute(sql)
+        # Encoded to bytes so the dynamically built command satisfies
+        # psycopg's LiteralString-typed query parameter.
+        conn.execute(sql.encode())
 
 
 def mz_setup(mode: Mode) -> None:
@@ -75,14 +77,34 @@ def mz_setup(mode: Mode) -> None:
         conn.execute(
             "CREATE CONNECTION pg TO POSTGRES (HOST 'localhost', PORT 5434, USER postgres, PASSWORD SECRET pgpass, DATABASE postgres)"
         )
-        conn.execute("CREATE SOURCE pg_src FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_pub')")
+        conn.execute(
+            "CREATE SOURCE pg_src FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_pub')"
+        )
         conn.execute("CREATE TABLE t FROM SOURCE pg_src (REFERENCE t)")
         deadline = time.monotonic() + 60
+        last_status = None
         while time.monotonic() < deadline:
-            row = conn.execute("SELECT count(*) FROM t").fetchone()
-            if row is not None:
+            row = conn.execute(
+                "SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'pg_src'"
+            ).fetchone()
+            last_status = row[0] if row is not None else None
+            if last_status == "running":
                 break
             time.sleep(0.5)
+        else:
+            raise RuntimeError(
+                f"pg_src did not reach running, last status: {last_status}"
+            )
+        last_error = None
+        while time.monotonic() < deadline:
+            try:
+                conn.execute("SELECT count(*) FROM t").fetchone()
+                break
+            except psycopg.Error as e:
+                last_error = str(e)
+                time.sleep(0.5)
+        else:
+            raise RuntimeError(f"table t not queryable, last error: {last_error}")
     # Set after CREATE SOURCE so the source keeps a 1s TIMESTAMP INTERVAL and
     # only the coordinator keepalive speeds up.
     mz_system(f"ALTER SYSTEM SET default_timestamp_interval = '{mode.keepalive_ms}ms'")
@@ -118,7 +140,6 @@ def reader(stop: threading.Event, samples: Samples) -> None:
 def binding_counter(stop: threading.Event, samples: Samples) -> None:
     with psycopg.connect(MZ_DSN, autocommit=False) as conn:
         cur = conn.cursor()
-        cur.execute("BEGIN")
         cur.execute("DECLARE c CURSOR FOR SUBSCRIBE (SELECT * FROM pg_src_progress)")
         while not stop.is_set():
             rows = cur.execute("FETCH ALL c WITH (timeout = '1s')").fetchall()
@@ -134,7 +155,9 @@ def pct(values: list[float], p: float) -> float:
     return values[idx]
 
 
-def run_mode(mode: Mode, duration_s: float, rate_hz: float) -> tuple[Mode, Samples, float]:
+def run_mode(
+    mode: Mode, duration_s: float, rate_hz: float
+) -> tuple[Mode, Samples, float]:
     mz_setup(mode)
     samples = Samples()
     stop = threading.Event()
@@ -162,12 +185,19 @@ def main() -> None:
 
     pg_setup()
     results = []
-    for mode in MODES:
-        if mode.name not in args.modes:
-            continue
-        results.append(run_mode(mode, args.duration, args.rate))
+    try:
+        for mode in MODES:
+            if mode.name not in args.modes:
+                continue
+            results.append(run_mode(mode, args.duration, args.rate))
+    finally:
+        mz_system("ALTER SYSTEM RESET default_timestamp_interval")
+        mz_system("ALTER SYSTEM RESET storage_event_driven_bindings")
+        mz_system("ALTER SYSTEM RESET storage_binding_lead")
 
-    print("| mode | staleness p50 ms | staleness p95 ms | read p50 ms | read p95 ms | bindings/s | reads | errors |")
+    print(
+        "| mode | staleness p50 ms | staleness p95 ms | read p50 ms | read p95 ms | bindings/s | reads | errors |"
+    )
     print("|---|---|---|---|---|---|---|---|")
     for mode, s, elapsed in results:
         print(
@@ -175,9 +205,6 @@ def main() -> None:
             f"| {pct(s.latency_ms, 0.5):.1f} | {pct(s.latency_ms, 0.95):.1f} "
             f"| {len(s.binding_timestamps) / elapsed:.2f} | {len(s.latency_ms)} | {s.errors} |"
         )
-    mz_system("ALTER SYSTEM RESET default_timestamp_interval")
-    mz_system("ALTER SYSTEM RESET storage_event_driven_bindings")
-    mz_system("ALTER SYSTEM RESET storage_binding_lead")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

Source freshness today is bounded by the one second `timestamp_interval`: a remap binding is minted once per probe tick, and a strict serializable read waits for the next binding to become visible. Lowering the interval multiplies consensus, oracle, and upstream probe load. The design doc in this PR proposes minting bindings when the source's data frontier advances, bounded by a minimum binding interval and the existing maximum, with a measured lead so reads do not wait on upper visibility. See `doc/developer/design/20260912_tickless_frontiers.md`.

### Description

Draft for design review; the code is a flag-gated prototype used to measure the design, not a finished feature.

* Design doc with the per-tick durable write costs of the current scheme, the proposed mechanism, the consensus budget, and prototype results.
* `storage_event_driven_bindings` (off in production, on in the mzcompose defaults), `storage_min_binding_interval` (250 ms), `storage_binding_lead` (0). With the flag off the remap operator behaves exactly as before and no new operator is rendered.
* Sources republish their export frontier as arrival probes. The remap operator floors `probe_ts + lead` to the minimum interval grid, defers a proposal that lands in a cell the remap upper already passed to the next cell, closes the shard on shutdown, and counts deferred and rejected proposals.
* A measurement harness under `test/tickless-spike/`.

Measured on a local PostgreSQL source at 20 inserts per second: staleness p50 1035 ms to 299 ms without lead, strict serializable read p95 254 ms to 22 ms with a 400 ms lead at the cost of staleness. The main open risk is that arrival-driven minting is inert while ingestion trails the last probed upstream frontier, which is Kafka under load and filtered PostgreSQL publications; this is unmeasured.

Posted by Claude Code on behalf of the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrGP7JvY9CAKMzMeVSFTzb